### PR TITLE
feat: Add admin query keys for users and buyers

### DIFF
--- a/src/pages/Admin/User/AddOrUpdate.jsx
+++ b/src/pages/Admin/User/AddOrUpdate.jsx
@@ -1,5 +1,11 @@
 import { AddModal } from '@/components/Modal';
-import { useFetch, useFetchForRhfReset, usePostFunc, useRHF, useUpdateFunc } from '@/hooks';
+import {
+	useFetch,
+	useFetchForRhfReset,
+	usePostFunc,
+	useRHF,
+	useUpdateFunc,
+} from '@/hooks';
 import { FormField, Input, PasswordInput, ReactSelect, Textarea } from '@/ui';
 import GetDateTime from '@/util/GetDateTime';
 import { PASSWORD, USER_NULL, USER_SCHEMA } from '@util/Schema';
@@ -17,13 +23,21 @@ export default function Index({
 		schema = {
 			...USER_SCHEMA,
 			pass: PASSWORD,
-			repeatPass: PASSWORD.oneOf([yup.ref('pass')], 'Passwords do not match'),
+			repeatPass: PASSWORD.oneOf(
+				[yup.ref('pass')],
+				'Passwords do not match'
+			),
 		};
 	}
-	const { register, handleSubmit, errors, reset, Controller, control, getValues } = useRHF(
-		schema,
-		USER_NULL
-	);
+	const {
+		register,
+		handleSubmit,
+		errors,
+		reset,
+		Controller,
+		control,
+		getValues,
+	} = useRHF(schema, USER_NULL);
 
 	useFetchForRhfReset(`hr/user/${updateUser?.uuid}`, updateUser?.uuid, reset);
 
@@ -71,7 +85,9 @@ export default function Index({
 		});
 	};
 
-	const { value: userDepartment } = useFetch('/user-department-designation/value/label');
+	const { value: userDepartment } = useFetch(
+		'/user-department-designation/value/label'
+	);
 
 	return (
 		<AddModal
@@ -80,7 +96,10 @@ export default function Index({
 			onSubmit={handleSubmit(onSubmit)}
 			onClose={onClose}>
 			<div className='flex flex-col gap-2 md:flex-row'>
-				<FormField label='department_designation' title='Department' errors={errors}>
+				<FormField
+					label='department_designation'
+					title='Department'
+					errors={errors}>
 					<Controller
 						name={'department_designation'}
 						control={control}
@@ -90,7 +109,9 @@ export default function Index({
 									placeholder='Select Department'
 									options={userDepartment}
 									value={userDepartment?.find(
-										(item) => item.value == getValues('department_designation')
+										(item) =>
+											item.value ==
+											getValues('department_designation')
 									)}
 									onChange={(e) => onChange(e.value)}
 								/>
@@ -109,7 +130,11 @@ export default function Index({
 
 			{updateUser?.uuid === null && (
 				<div className='mb-4 flex flex-col gap-2 md:flex-row'>
-					<PasswordInput title='Password' label='pass' {...{ register, errors }} />
+					<PasswordInput
+						title='Password'
+						label='pass'
+						{...{ register, errors }}
+					/>
 					<PasswordInput
 						title='Repeat Password'
 						label='repeatPass'

--- a/src/state/Admin/QueryKeys.jsx
+++ b/src/state/Admin/QueryKeys.jsx
@@ -1,0 +1,19 @@
+// Effective React Query Keys
+// https://tkdodo.eu/blog/effective-react-query-keys#use-query-key-factories
+// https://tkdodo.eu/blog/leveraging-the-query-function-context#query-key-factories
+
+export const adminQK = {
+	all: () => ['admin'],
+
+	// details
+	details: () => [...adminQK.all(), 'details'],
+	detail: (id) => [...adminQK.details(), id],
+
+	// info
+	users: () => [...adminQK.all(), 'users'],
+	user: (uuid) => [...adminQK.infos(), uuid],
+
+	// buyers
+	buyers: () => [...adminQK.all(), 'buyers'],
+	buyer: (uuid) => [...adminQK.buyers(), uuid],
+};

--- a/src/state/Admin/user.jsx
+++ b/src/state/Admin/user.jsx
@@ -1,0 +1,24 @@
+import { api } from '@/lib/api';
+import createGlobalState from '@/state';
+import { useEffect } from 'react';
+import { adminQK } from './QueryKeys';
+
+export const useAdminUsers = () =>
+	createGlobalState({
+		queryKey: adminQK.users(),
+		url: '/hr/user',
+	});
+
+// const useFetchForRhfReset = async (uri, returnId, reset) => {
+// 	useEffect(async () => {
+// 		if (returnId === null || returnId === undefined) return;
+
+// 		await api.get(uri).then((res) => reset(res?.data[0]));
+// 	}, [returnId]);
+// };
+
+export const useOrderBuyerByUUID = (uuid) =>
+	createGlobalState({
+		queryKey: orderQK.buyer(uuid),
+		url: `/public/buyer/${uuid}`,
+	});

--- a/src/state/index.jsx
+++ b/src/state/index.jsx
@@ -164,8 +164,6 @@ export default function useGlobalState({ queryKey, url }) {
 
 	const postData = useMutation({
 		mutationFn: async ({ url, newData }) => {
-			console.log('postData -> newData', newData);
-
 			const response = await api.post(url, newData);
 			return response.data;
 		},
@@ -188,6 +186,8 @@ export default function useGlobalState({ queryKey, url }) {
 			queryClient.setQueryData(queryKey, (old) =>
 				old.filter((val) => val.id !== context.newData.uuid)
 			);
+
+			console.log('react query error: ', error);
 		},
 		onSettled: (data, error, variables, context) => {
 			// queryClient.invalidateQueries({ queryKey });


### PR DESCRIPTION
The code changes include adding query keys for users and buyers in the admin section. This will allow for more efficient querying and retrieval of data related to users and buyers. The changes also include updating the printWidth in the prettierrc file and removing unused files. Additionally, there are updates to the nanoid generation in the nanoid.jsx and buyer.jsx files.

Please note that the recent user commits and repository commits are not directly related to the code changes mentioned above.