### PR TITLE
Update GetDateTime format to use 24-hour time

### DIFF
--- a/src/pages/Order/Merchandiser/AddOrUpdate.jsx
+++ b/src/pages/Order/Merchandiser/AddOrUpdate.jsx
@@ -6,11 +6,11 @@ import {
 	useRHF,
 	useUpdateFunc,
 } from '@/hooks';
+import nanoid from '@/lib/nanoid';
+import { useOrderMerchandiser } from '@/state/Order';
 import { FormField, Input, ReactSelect, Textarea } from '@/ui';
 import GetDateTime from '@/util/GetDateTime';
 import { MERCHANDISER_NULL, MERCHANDISER_SCHEMA } from '@util/Schema';
-import { useOrderMerchandiser } from '@/state/Order';
-import nanoid from '@/lib/nanoid';
 
 export default function Index({
 	modalId = '',
@@ -76,7 +76,7 @@ export default function Index({
 			...data,
 			uuid: nanoid(),
 			party_name: party_name,
-			created_at: new Date(),
+			created_at: GetDateTime(),
 		};
 
 		console.log(updatedData);

--- a/src/util/GetDateTime.jsx
+++ b/src/util/GetDateTime.jsx
@@ -1,5 +1,5 @@
-import { format } from "date-fns";
+import { format } from 'date-fns';
 
-const GetDateTime = () => format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSS'Z");
+const GetDateTime = () => format(new Date(), 'yyyy-MM-dd HH:mm:ss');
 
 export default GetDateTime;


### PR DESCRIPTION
This pull request updates the `GetDateTime` function to use a 24-hour time format instead of the previous format. The function now returns the date and time in the format "yyyy-MM-dd HH:mm:ss". This change ensures consistency in the date and time formatting throughout the codebase.