### PR TITLE
Add conversion rate and receive amount fields to cash entry form

### DIFF
--- a/src/pages/Commercial/Cash/Entry/index.jsx
+++ b/src/pages/Commercial/Cash/Entry/index.jsx
@@ -169,6 +169,9 @@ export default function Index() {
 				validity: data?.validity,
 				payment: data?.payment,
 				remarks: data?.remarks,
+				conversion_rate: data?.conversion_rate,
+				receive_amount: data?.receive_amount,
+				remarks: data?.remarks,
 				updated_at: GetDateTime(),
 				is_pi: 0,
 			};
@@ -296,7 +299,7 @@ export default function Index() {
 
 			try {
 				const commercialPiPromise = await updateData.mutateAsync({
-					url: `/commercial/pi-cash/${data?.uuid}?is_cash=true`,
+					url: `/commercial/pi-cash/${data?.uuid}`,
 					updatedData: commercialPiData,
 					uuid: data.uuid,
 					isOnCloseNeeded: false,


### PR DESCRIPTION
This pull request adds the conversion rate and receive amount fields to the cash entry form in the Commercial Cash module. These fields allow users to enter the conversion rate and the amount received for a cash transaction. The changes include updating the form component to include the new fields and updating the API endpoint for updating cash transactions. This pull request addresses issues #174 and #173.