### PR TITLE
feat:Add account number and tax information to Proforma Invoice

### DIFF
--- a/src/components/Pdf/ProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ProformaInvoice/utils.jsx
@@ -34,8 +34,8 @@ export const getPageHeader = (data) => {
 					text: [
 						`${company.address}\n`,
 						`${company.phone}\n`,
-						'BIN:000537296-0403\n',
-						'VAT:17141000815\n',
+						`${company.bin}\n`,
+						`${company.tax}\n`,
 					],
 					alignment: 'left',
 				},

--- a/src/components/Pdf/ProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ProformaInvoice/utils.jsx
@@ -69,15 +69,15 @@ export const getPageHeader = (data) => {
 			[
 				{ text: 'Buyer', bold: true, color: PRIMARY_COLOR },
 				{ text: [...buyer].join(', ') },
-				{ text: 'SWIFT', bold: true, color: PRIMARY_COLOR },
-				data?.bank_swift_code,
+				{ text: 'Account No', bold: true, color: PRIMARY_COLOR },
+				data?.bank_account_no,
 			],
 
 			[
 				{ text: 'Attention', bold: true, color: PRIMARY_COLOR },
 				data?.merchandiser_name,
-				{ text: 'Routing No', bold: true, color: PRIMARY_COLOR },
-				data?.bank_routing_no,
+				{ text: 'SWIFT', bold: true, color: PRIMARY_COLOR },
+				data?.bank_swift_code,
 			],
 
 			[
@@ -87,8 +87,8 @@ export const getPageHeader = (data) => {
 					color: PRIMARY_COLOR,
 				},
 				{ text: Number(data?.weight) > 0 ? data?.weight + ' Kg' : '' },
-				'',
-				'',
+				{ text: 'Routing No', bold: true, color: PRIMARY_COLOR },
+				data?.bank_routing_no,
 			],
 		],
 	};

--- a/src/components/Pdf/ProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ProformaInvoice/utils.jsx
@@ -31,7 +31,12 @@ export const getPageHeader = (data) => {
 				},
 				{
 					colspan: 2,
-					text: [`${company.address}\n`, `${company.phone}\n`],
+					text: [
+						`${company.address}\n`,
+						`${company.phone}\n`,
+						'BIN:000537296-0403\n',
+						'VAT:17141000815\n',
+					],
 					alignment: 'left',
 				},
 

--- a/src/pages/Commercial/Bank/AddOrUpdate.jsx
+++ b/src/pages/Commercial/Bank/AddOrUpdate.jsx
@@ -83,6 +83,7 @@ export default function Index({
 			onClose={onClose}
 			isSmall={true}>
 			<Input label='name' {...{ register, errors }} />
+			<Input label='account_no' {...{ register, errors }} />
 			<Input label='swift_code' {...{ register, errors }} />
 			<Input label='routing_no' {...{ register, errors }} />
 			<Textarea label='address' rows='2' {...{ register, errors }} />

--- a/src/pages/Commercial/Bank/index.jsx
+++ b/src/pages/Commercial/Bank/index.jsx
@@ -27,6 +27,12 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'account_no',
+				header: 'Account No',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorKey: 'swift_code',
 				header: 'Swift Code',
 				enableColumnFilter: false,

--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -1,36 +1,36 @@
 import { startOfDay } from 'date-fns';
 import * as yup from 'yup';
 
-
-
 import GetDateTime from '../GetDateTime';
-import { BOOLEAN // default
-, BOOLEAN_DEFAULT_VALUE // default
-, BOOLEAN_REQUIRED // default
-, EMAIL // default
-, EMAIL_REQUIRED // default
-, FORTUNE_ZIP_EMAIL_PATTERN // default
-, JSON_STRING // default
-, JSON_STRING_REQUIRED // default
-, NAME, NAME_REQUIRED // default
-, NUMBER // default
-, NUMBER_DOUBLE // default
-, NUMBER_DOUBLE_REQUIRED // default
-, NUMBER_REQUIRED // default
-, ORDER_NUMBER // default
-, ORDER_NUMBER_NOT_REQUIRED // default
-, PASSWORD // default
-, PHONE_NUMBER // default
-, PHONE_NUMBER_REQUIRED // default
-, STRING // default
-, STRING_REQUIRED // default
-, URL // default
-, URL_REQUIRED // default
-, UUID // default
-, UUID_FK // default
-, UUID_PK // default
-, UUID_REQUIRED } from './utils';
-
+import {
+	BOOLEAN, // default
+	BOOLEAN_DEFAULT_VALUE, // default
+	BOOLEAN_REQUIRED, // default
+	EMAIL, // default
+	EMAIL_REQUIRED, // default
+	FORTUNE_ZIP_EMAIL_PATTERN, // default
+	JSON_STRING, // default
+	JSON_STRING_REQUIRED, // default
+	NAME,
+	NAME_REQUIRED, // default
+	NUMBER, // default
+	NUMBER_DOUBLE, // default
+	NUMBER_DOUBLE_REQUIRED, // default
+	NUMBER_REQUIRED, // default
+	ORDER_NUMBER, // default
+	ORDER_NUMBER_NOT_REQUIRED, // default
+	PASSWORD, // default
+	PHONE_NUMBER, // default
+	PHONE_NUMBER_REQUIRED, // default
+	STRING, // default
+	STRING_REQUIRED, // default
+	URL, // default
+	URL_REQUIRED, // default
+	UUID, // default
+	UUID_FK, // default
+	UUID_PK, // default
+	UUID_REQUIRED,
+} from './utils';
 
 export {
 	BOOLEAN,

--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -1,36 +1,36 @@
 import { startOfDay } from 'date-fns';
 import * as yup from 'yup';
 
+
+
 import GetDateTime from '../GetDateTime';
-import {
-	BOOLEAN, // default
-	BOOLEAN_DEFAULT_VALUE, // default
-	BOOLEAN_REQUIRED, // default
-	EMAIL, // default
-	EMAIL_REQUIRED, // default
-	FORTUNE_ZIP_EMAIL_PATTERN, // default
-	JSON_STRING, // default
-	JSON_STRING_REQUIRED, // default
-	NAME,
-	NAME_REQUIRED, // default
-	NUMBER, // default
-	NUMBER_DOUBLE, // default
-	NUMBER_DOUBLE_REQUIRED, // default
-	NUMBER_REQUIRED, // default
-	ORDER_NUMBER, // default
-	ORDER_NUMBER_NOT_REQUIRED, // default
-	PASSWORD, // default
-	PHONE_NUMBER, // default
-	PHONE_NUMBER_REQUIRED, // default
-	STRING, // default
-	STRING_REQUIRED, // default
-	URL, // default
-	URL_REQUIRED, // default
-	UUID, // default
-	UUID_FK, // default
-	UUID_PK, // default
-	UUID_REQUIRED,
-} from './utils';
+import { BOOLEAN // default
+, BOOLEAN_DEFAULT_VALUE // default
+, BOOLEAN_REQUIRED // default
+, EMAIL // default
+, EMAIL_REQUIRED // default
+, FORTUNE_ZIP_EMAIL_PATTERN // default
+, JSON_STRING // default
+, JSON_STRING_REQUIRED // default
+, NAME, NAME_REQUIRED // default
+, NUMBER // default
+, NUMBER_DOUBLE // default
+, NUMBER_DOUBLE_REQUIRED // default
+, NUMBER_REQUIRED // default
+, ORDER_NUMBER // default
+, ORDER_NUMBER_NOT_REQUIRED // default
+, PASSWORD // default
+, PHONE_NUMBER // default
+, PHONE_NUMBER_REQUIRED // default
+, STRING // default
+, STRING_REQUIRED // default
+, URL // default
+, URL_REQUIRED // default
+, UUID // default
+, UUID_FK // default
+, UUID_PK // default
+, UUID_REQUIRED } from './utils';
+
 
 export {
 	BOOLEAN,
@@ -2044,6 +2044,7 @@ export const PI_CASH_RECEIVE_NULL = {
 
 export const BANK_SCHEMA = {
 	name: STRING_REQUIRED,
+	account_no: STRING.nullable(),
 	swift_code: STRING_REQUIRED,
 	routing_no: STRING.nullable(),
 	address: STRING_REQUIRED,
@@ -2054,6 +2055,7 @@ export const BANK_SCHEMA = {
 export const BANK_NULL = {
 	uuid: null,
 	name: '',
+	account_no: '',
 	swift_code: '',
 	routing_no: '',
 	address: '',


### PR DESCRIPTION
Introduce an account number field and update bank details, including BIN and VAT information, in the Proforma Invoice.