### PR TITLE
fix:Add poly quantity display for packing numbers in Zipper Challan PDF

### DIFF
--- a/src/components/Pdf/ZipperChallan/index.jsx
+++ b/src/components/Pdf/ZipperChallan/index.jsx
@@ -309,6 +309,18 @@ export default function Index(data) {
 											alignment: 'right',
 											fontSize: DEFAULT_FONT_SIZE + 2,
 										},
+										{
+											text: uniqueCounts(
+												challan_entry?.filter(
+													(item) =>
+														item.packing_number ===
+														pl.packing_number
+												)
+											).poly_quantity,
+											bold: true,
+											alignment: 'right',
+											fontSize: DEFAULT_FONT_SIZE + 2,
+										},
 									],
 					],
 				},


### PR DESCRIPTION
Introduce a display for poly quantity associated with packing numbers in the Zipper Challan PDF.