### PR TITLE
Format expected weight to three decimal places in Thread Travel Card PDF

### DIFF
--- a/src/components/Pdf/ThreadTravelCard/index.jsx
+++ b/src/components/Pdf/ThreadTravelCard/index.jsx
@@ -31,7 +31,9 @@ export default function Index(batch, shade_recipes_entries, programs) {
 	let footerHeight = 50;
 	const { batch_entry } = batch;
 	batch_entry?.forEach((item) => {
-		const expected_weight = item?.quantity * item?.max_weight;
+		const expected_weight = Number(
+			item?.quantity * item?.max_weight
+		).toFixed(3);
 		item['expected_weight'] = expected_weight;
 	});
 


### PR DESCRIPTION
Ensure the expected weight is displayed with three decimal places in the Thread Travel Card PDF.