### PR TITLE
Exclude specific sizes from grand total calculations in DailyProduction PDF

### DIFF
--- a/src/components/Pdf/DailyProduction/index.jsx
+++ b/src/components/Pdf/DailyProduction/index.jsx
@@ -197,14 +197,17 @@ export default function Index(data, from) {
 		});
 	});
 	const grandTotalCloseEnd = tableData.reduce((total, item) => {
+		if (title.includes(item.size.text)) return total;
 		return total + (item.running_total_close_end_quantity?.text || 0);
 	}, 0);
 
 	const grandTotalOpenEnd = tableData.reduce((total, item) => {
+		if (title.includes(item.size.text)) return total;
 		return total + (item.running_total_open_end_quantity?.text || 0);
 	}, 0);
 
 	const grandTotalQuantity = tableData.reduce((total, item) => {
+		if (title.includes(item.size.text)) return total;
 		return total + (item.running_total_quantity?.text || 0);
 	}, 0);
 


### PR DESCRIPTION
Exclude certain sizes from the grand total calculations in the DailyProduction PDF to ensure accurate reporting.