### PR TITLE
Ensure itemTotal defaults to 0 in tape calculation

### DIFF
--- a/src/pages/DyeingAndIron/ZipperBatch/Entry/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/Entry/index.jsx
@@ -159,11 +159,12 @@ export default function Index() {
 			const rawMtrPerKg = parseFloat(item.raw_mtr_per_kg) || 1;
 
 			// * for tape order we calculate with size as quantity
-			const itemTotal = getRequiredTapeKg({
-				row: item,
-				type: 'raw',
-				input_quantity: quantity,
-			});
+			const itemTotal =
+				getRequiredTapeKg({
+					row: item,
+					type: 'raw',
+					input_quantity: quantity,
+				}) || 0;
 			return acc + itemTotal;
 		}, 0);
 	}, []);


### PR DESCRIPTION
Modify the calculation of itemTotal to default to 0 when no value is returned from getRequiredTapeKg. This change improves the robustness of the tape order calculation.