### PR TITLE
Add report selection functionality in ProductionStatement header

### DIFF
--- a/src/pages/Report/ProductionStatement/Header.jsx
+++ b/src/pages/Report/ProductionStatement/Header.jsx
@@ -25,12 +25,18 @@ export default function Header({
 	setMarketing = () => {},
 	order = '',
 	setOrder = () => {},
+	reportFor = '',
+	setReportFor = () => {},
 }) {
 	const { data: marketings } = useOtherMarketing();
 	const { data: parties } = useOtherParty();
 	const { data: orders } = useAllZipperThreadOrderList(
-		`from_date=${from}&to_date=${to}&page=production_statement`
+		`from_date=${from}&to_date=${to}&page=production_statement${reportFor === 'accounts' ? '_accounts' : ''}`
 	);
+	const reportForOptions = [
+		{ label: 'SNO', value: '' },
+		{ label: 'Accounts', value: 'accounts' },
+	];
 
 	const types = [
 		{ label: 'Nylon', value: 'Nylon' },
@@ -90,6 +96,18 @@ export default function Header({
 					</FormField>
 				</div>
 				<div className='flex gap-2'>
+					<FormField label='' title='Report For'>
+						<ReactSelect
+							placeholder='Select Report'
+							options={reportForOptions}
+							value={reportForOptions?.find(
+								(item) => item.value == reportFor
+							)}
+							onChange={(e) => {
+								setReportFor(e.value);
+							}}
+						/>
+					</FormField>
 					<FormField label='' title='Type'>
 						<ReactSelect
 							placeholder='Select Type'

--- a/src/pages/Report/ProductionStatement/index.jsx
+++ b/src/pages/Report/ProductionStatement/index.jsx
@@ -22,13 +22,15 @@ export default function index() {
 	const [type, setType] = useState();
 	const [party, setParty] = useState();
 	const [order, setOrder] = useState('');
+	const [reportFor, setReportFor] = useState('');
 	const { data, isLoading } = useProductionStatementReport(
 		from,
 		to,
 		party,
 		marketing,
 		type,
-		order
+		order,
+		reportFor
 	);
 
 	useEffect(() => {
@@ -53,6 +55,8 @@ export default function index() {
 					setType,
 					order,
 					setOrder,
+					reportFor,
+					setReportFor,
 				}}
 			/>
 			<div className='flex gap-2'>

--- a/src/state/QueryKeys.jsx
+++ b/src/state/QueryKeys.jsx
@@ -1528,7 +1528,8 @@ export const reportQK = {
 		party,
 		marketing,
 		type,
-		order
+		order,
+		reportFor
 	) => [
 		...reportQK.all(),
 		'production-report',
@@ -1538,6 +1539,7 @@ export const reportQK = {
 		marketing,
 		type,
 		order,
+		reportFor,
 	],
 	//* Zipper Production
 	zipperProduction: (query) => [

--- a/src/state/Report.jsx
+++ b/src/state/Report.jsx
@@ -34,7 +34,8 @@ export const useProductionStatementReport = (
 	party = '',
 	marketing = '',
 	type = '',
-	order = ''
+	order = '',
+	reportFor = ''
 ) =>
 	createGlobalState({
 		queryKey: reportQK.productionReportStatementReport(
@@ -43,9 +44,10 @@ export const useProductionStatementReport = (
 			party,
 			marketing,
 			type,
-			order
+			order,
+			reportFor
 		),
-		url: `/report/delivery-statement-report?from_date=${from}&to_date=${to}&party=${party}&marketing=${marketing}&order_info_uuid=${order}&type=${type}&page=production_statement`,
+		url: `/report/delivery-statement-report?from_date=${from}&to_date=${to}&party=${party}&marketing=${marketing}&order_info_uuid=${order}&type=${type}&report_for=${reportFor}`,
 		enabled: !!from && !!to,
 	});
 


### PR DESCRIPTION
Introduce a report selection feature in the ProductionStatement header, allowing users to choose between different report types. This enhances the filtering capabilities of the report generation process.