### PR TITLE
Update company information in PDF headers

### DIFF
--- a/src/components/Pdf/ManualProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ManualProformaInvoice/utils.jsx
@@ -27,7 +27,12 @@ export const getPageHeader = (data) => {
 				},
 				{
 					colspan: 2,
-					text: [`${company.address}\n`, `${company.phone}\n`],
+					text: [
+						`${company.name}\n`,
+						`${company.address}\n`,
+						`${company.bin}\n`,
+						`${company.tax}\n`,
+					],
 					alignment: 'left',
 				},
 

--- a/src/components/Pdf/ProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ProformaInvoice/utils.jsx
@@ -36,8 +36,8 @@ export const getPageHeader = (data) => {
 								},
 								{
 									text: [
+										`${company.name}\n`,
 										`${company.address}\n`,
-										`${company.phone}\n`,
 										`${company.bin}\n`,
 										`${company.tax}\n`,
 									],

--- a/src/components/Pdf/utils.jsx
+++ b/src/components/Pdf/utils.jsx
@@ -103,7 +103,7 @@ export const CUSTOM_PAGE_CONE_STICKER = ({
 
 export const company = {
 	logo: FZL_LOGO.src,
-	name: 'Fortune Zipper LTD.',
+	name: 'Fortune Zipper Limited.',
 	address: 'Aukpara, Ashulia, Savar, DHK-1340',
 	email: 'Email: info@fortunezip.com',
 	phone: 'Phone: 01810001301',


### PR DESCRIPTION
Revise company details in PDF headers to include the company name, BIN, and tax information, while correcting the company name to "Fortune Zipper Limited."