### PR TITLE
Add gross weight to details page

### DIFF
--- a/src/components/Pdf/ProformaInvoice/index.jsx
+++ b/src/components/Pdf/ProformaInvoice/index.jsx
@@ -389,7 +389,7 @@ export default function Index(data) {
 		header: {
 			table: getPageHeader(data),
 			layout: 'noBorders',
-			margin: [xMargin, 30, xMargin, 0],
+			margin: [xMargin, 10, xMargin, 0],
 		},
 		// * Page Footer
 		footer: (currentPage, pageCount) => ({

--- a/src/components/Pdf/ProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ProformaInvoice/utils.jsx
@@ -135,7 +135,7 @@ export const getPageHeader = (data) => {
 								{
 									text:
 										Number(data?.weight) > 0
-											? 'Weight'
+											? 'Net Weight'
 											: '',
 									bold: true,
 									color: PRIMARY_COLOR,
@@ -157,7 +157,7 @@ export const getPageHeader = (data) => {
 								{
 									text:
 										Number(data?.cross_weight) > 0
-											? 'Cross Weight'
+											? 'Gross Weight'
 											: '',
 									bold: true,
 									color: PRIMARY_COLOR,

--- a/src/components/Pdf/ProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ProformaInvoice/utils.jsx
@@ -153,6 +153,24 @@ export const getPageHeader = (data) => {
 								},
 								data?.bank_routing_no,
 							],
+							[
+								{
+									text:
+										Number(data?.cross_weight) > 0
+											? 'Cross Weight'
+											: '',
+									bold: true,
+									color: PRIMARY_COLOR,
+								},
+								{
+									text:
+										Number(data?.cross_weight) > 0
+											? data?.cross_weight + ' Kg'
+											: '',
+								},
+								'',
+								'',
+							],
 						],
 					},
 					layout: 'noBorders',

--- a/src/pages/Commercial/PI/Details/Information.jsx
+++ b/src/pages/Commercial/PI/Details/Information.jsx
@@ -31,6 +31,8 @@ export default function Information({ pi }) {
 		factory_address,
 		validity,
 		payment,
+		weight,
+		cross_weight,
 		created_by,
 		created_by_name,
 		created_at,
@@ -176,6 +178,14 @@ export default function Information({ pi }) {
 			{
 				label: 'Validity',
 				value: validity + ' Days',
+			},
+			{
+				label: 'Net Weight',
+				value: weight + ' Kg',
+			},
+			{
+				label: 'Gross Weight',
+				value: cross_weight + ' Kg',
 			},
 		];
 

--- a/src/pages/Commercial/PI/Entry/Header.jsx
+++ b/src/pages/Commercial/PI/Entry/Header.jsx
@@ -221,6 +221,7 @@ export default function Header({
 					{...{ register, errors }}
 				/>
 				<JoinInput
+					title='Gross weight'
 					label='cross_weight'
 					unit='KG'
 					{...{ register, errors }}


### PR DESCRIPTION
Introduce gross weight and cross weight fields to the details page, enhancing the information displayed for better clarity. Adjustments made to the layout and labels for improved presentation.