### PR TITLE
Refactor balance calculation to use batch quantity

### DIFF
--- a/src/pages/Slider/Dashboard/index.jsx
+++ b/src/pages/Slider/Dashboard/index.jsx
@@ -271,9 +271,9 @@ export default function Index() {
 			},
 			{
 				accessorFn: (row) => {
-					const { swatch_approved_quantity, trx_to_finishing } = row;
+					const { batch_quantity, trx_to_finishing } = row;
 
-					return swatch_approved_quantity - trx_to_finishing;
+					return batch_quantity - trx_to_finishing;
 				},
 				header: 'Balance',
 				id: 'balance',


### PR DESCRIPTION
Update the balance calculation to utilize `batch_quantity` instead of `swatch_approved_quantity` for improved accuracy.