### PR TITLE
Add 'Unit' column and improve header clarity in delivery reports

### DIFF
--- a/src/pages/Report/DeliveryReport/Thread.jsx
+++ b/src/pages/Report/DeliveryReport/Thread.jsx
@@ -137,26 +137,34 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'unit',
+				header: 'Unit',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorKey: 'delivered_quantity',
 				header: 'Delivered QTY',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
+
 			{
 				accessorKey: 'reject_quantity',
 				header: 'Return QTY',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
+
 			{
 				accessorKey: 'rate_per_piece',
-				header: 'Rate Per Piece',
+				header: 'Rate/PCS',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
 			{
 				accessorKey: 'commission',
-				header: 'Commission',
+				header: 'Comm.',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
@@ -168,7 +176,7 @@ export default function Index() {
 			},
 			{
 				accessorKey: 'total_commission',
-				header: 'Total Commission',
+				header: 'Total Comm.',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},

--- a/src/pages/Report/DeliveryReport/Zipper.jsx
+++ b/src/pages/Report/DeliveryReport/Zipper.jsx
@@ -112,7 +112,17 @@ export default function Index() {
 				header: 'Description',
 				enableColumnFilter: false,
 				width: 'w-32',
-				cell: (info) => info.getValue(),
+				cell: (info) => {
+					const { order_description_uuid, order_number } =
+						info.row.original;
+					return (
+						<CustomLink
+							label={info.getValue()}
+							url={`/order/details/${order_number}/${order_description_uuid}`}
+							openInNewTab={true}
+						/>
+					);
+				},
 			},
 
 			{
@@ -133,7 +143,12 @@ export default function Index() {
 				accessorKey: 'size',
 				header: 'Size',
 				enableColumnFilter: false,
-				width: 'w-32',
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'unit',
+				header: 'Unit',
+				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
 
@@ -157,19 +172,19 @@ export default function Index() {
 			},
 			{
 				accessorKey: 'rate_per_dzn',
-				header: 'Rate Per Dzn',
+				header: 'Rate/DZN',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
 			{
 				accessorKey: 'rate_per_piece',
-				header: 'Rate Per Piece',
+				header: 'Rate/PCS',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
 			{
 				accessorKey: 'commission',
-				header: 'Commission',
+				header: 'Comm.',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
@@ -181,7 +196,7 @@ export default function Index() {
 			},
 			{
 				accessorKey: 'total_commission',
-				header: 'Total Commission',
+				header: 'Total Comm.',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},


### PR DESCRIPTION
Introduce a new 'Unit' column in delivery reports and update existing headers for better clarity.