### PR TITLE
Add price columns to order status reports with conditional visibility

### DIFF
--- a/src/pages/Report/OrderStatus/Thread.jsx
+++ b/src/pages/Report/OrderStatus/Thread.jsx
@@ -146,6 +146,20 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'party_price',
+				header: 'Party Price',
+				enableColumnFilter: false,
+				hidden: !haveAccess.includes('show_price'),
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'company_price',
+				header: 'Company Price',
+				enableColumnFilter: false,
+				hidden: !haveAccess.includes('show_price'),
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorKey: 'created_at',
 				header: 'Created',
 				enableColumnFilter: false,

--- a/src/pages/Report/OrderStatus/Zipper.jsx
+++ b/src/pages/Report/OrderStatus/Zipper.jsx
@@ -178,6 +178,20 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'party_price',
+				header: 'Party Price',
+				enableColumnFilter: false,
+				hidden: !haveAccess.includes('show_price'),
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'company_price',
+				header: 'Company Price',
+				enableColumnFilter: false,
+				hidden: !haveAccess.includes('show_price'),
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorKey: 'created_at',
 				header: 'Created',
 				enableColumnFilter: false,

--- a/src/routes/private/Report.jsx
+++ b/src/routes/private/Report.jsx
@@ -158,7 +158,7 @@ export const ReportRoutes = [
 				path: '/report/order-status',
 				element: <OrderStatus />,
 				page_name: 'report__order_status',
-				actions: ['read', 'show_own_orders'],
+				actions: ['read', 'show_own_orders','show_price'],
 			},
 			{
 				name: 'Approved Orders',


### PR DESCRIPTION
Introduce price columns for party and company in order status reports, displaying them based on user access permissions.