### PR TITLE
Add Thread Delivery report feature

### DIFF
--- a/src/pages/Report/ThreadDelivery/index.jsx
+++ b/src/pages/Report/ThreadDelivery/index.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@/context/auth';
+import { useThreadDelivery } from '@/state/Report';
+import { format, startOfMonth, subMonths } from 'date-fns';
+import { useAccess } from '@/hooks';
+
+import ReactTable from '@/components/Table';
+import { CustomLink, DateTime, SimpleDatePicker } from '@/ui';
+
+import PageInfo from '@/util/PageInfo';
+
+export default function Index() {
+	const haveAccess = useAccess('report__thread_delivery');
+	const { user } = useAuth();
+
+	const [date, setDate] = useState(new Date());
+	const [toDate, setToDate] = useState(new Date());
+	const { data, isLoading, url } = useThreadDelivery(
+		format(date, 'yyyy-MM-dd'),
+		format(toDate, 'yyyy-MM-dd')
+	);
+	const info = new PageInfo(
+		'Thread Delivery',
+		url,
+		'report__thread_delivery'
+	);
+
+	useEffect(() => {
+		document.title = info.getTabName();
+	}, []);
+
+	const columns = useMemo(
+		() => [
+			{
+				accessorKey: 'sum',
+				header: 'Sum',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'concat',
+				header: 'Concat',
+				enableColumnFilter: false,
+				width: 'w-32',
+				cell: (info) => info.getValue(),
+			},
+		],
+		[data]
+	);
+
+	if (isLoading)
+		return <span className='loading loading-dots loading-lg z-50' />;
+
+	return (
+		<ReactTable
+			key='bulk'
+			title={info.getTitle()}
+			accessor={false}
+			data={data}
+			columns={columns}
+			extraClass={'py-0.5'}
+			extraButton={
+				<div className='flex items-center gap-2'>
+					<SimpleDatePicker
+						className='h-[2.34rem] w-32'
+						key={'Date'}
+						value={date}
+						placeholder='Date'
+						onChange={(data) => {
+							setDate(data);
+						}}
+						selected={date}
+					/>
+					<SimpleDatePicker
+						className='h-[2.34rem] w-32'
+						key={'toDate'}
+						value={toDate}
+						placeholder='To'
+						onChange={(data) => {
+							setToDate(data);
+						}}
+						selected={toDate}
+					/>
+				</div>
+			}
+		/>
+	);
+}

--- a/src/routes/private/Report.jsx
+++ b/src/routes/private/Report.jsx
@@ -29,6 +29,7 @@ const ChallanStatus = lazy(() => import('@/pages/Report/ChallanStatus'));
 const OrderTracking = lazy(() => import('@/pages/Report/OrderTracking'));
 const OrderSummary = lazy(() => import('@/pages/Report/OrderSummary'));
 const DeliveryReport = lazy(() => import('@/pages/Report/DeliveryReport'));
+const ThreadDelivery = lazy(() => import('@/pages/Report/ThreadDelivery'));
 
 export const ReportRoutes = [
 	{
@@ -131,7 +132,7 @@ export const ReportRoutes = [
 				path: '/report/order-status',
 				element: <OrderStatus />,
 				page_name: 'report__order_status',
-				actions: ['read', 'show_own_orders','show_price'],
+				actions: ['read', 'show_own_orders', 'show_price'],
 			},
 			{
 				name: 'Approved Orders',
@@ -167,6 +168,13 @@ export const ReportRoutes = [
 				element: <DeliveryReport />,
 				page_name: 'report__delivery_report',
 				actions: ['read', 'show_price', 'show_own_orders'],
+			},
+			{
+				name: 'Thread Delivery',
+				path: '/report/thread-delivery',
+				element: <ThreadDelivery />,
+				page_name: 'report__thread_delivery',
+				actions: ['read', 'show_own_orders'],
 			},
 		],
 	},

--- a/src/state/QueryKeys.jsx
+++ b/src/state/QueryKeys.jsx
@@ -1667,6 +1667,16 @@ export const reportQK = {
 		is_sample,
 		...(query ? [query] : []),
 	],
+
+	// * Thread delivery
+	threadDelivery: (date, toDate, query) => [
+		...reportQK.all(),
+		'thread-delivery',
+		date,
+		toDate,
+		...(query ? [query] : []),
+	],
+
 	sampleCombined: (date, is_sample, query) => [
 		...reportQK.all(),
 		'sample-report-by-date-combined',

--- a/src/state/Report.jsx
+++ b/src/state/Report.jsx
@@ -211,6 +211,15 @@ export const useSample = (
 		enabled,
 	});
 
+export const useThreadDelivery = (date, toDate, query) =>
+	createGlobalState({
+		queryKey: reportQK.threadDelivery(date, toDate, query),
+		url: query
+			? `/report/count-length-wise-delivery-report?from=${date}&to=${toDate}` +
+				query
+			: `/report/count-length-wise-delivery-report?from=${date}&to=${toDate}`,
+	});
+
 export const useOrderTracing = (date, toDate, query) =>
 	createGlobalState({
 		queryKey: reportQK.orderTracking(date, toDate, query),


### PR DESCRIPTION
Introduce a new report for Thread Delivery, including a dedicated page and hooks for data fetching. Update routing to include the new report and ensure proper access controls.