### PR TITLE
Add a flex container for iframe elements in PI details page

### DIFF
--- a/src/pages/Commercial/PI/Details/index.jsx
+++ b/src/pages/Commercial/PI/Details/index.jsx
@@ -50,6 +50,8 @@ export default function Index() {
 					src={data2}
 					className='h-[40rem] w-full rounded-md border-none'
 				/>
+			</div>
+			<div className='flex gap-2'>
 				<iframe
 					src={data3}
 					className='h-[40rem] w-full rounded-md border-none'


### PR DESCRIPTION
Introduce a new flex container to improve the layout of iframe elements on the PI details page.