### PR TITLE
Refactor export LC date handling and update schema for nullable fields

### DIFF
--- a/src/pages/Commercial/LC/Details/Information.jsx
+++ b/src/pages/Commercial/LC/Details/Information.jsx
@@ -110,7 +110,7 @@ export default function Information({ lc }) {
 
 		export_lc_number,
 		export_lc_date,
-		export_lc_expire_date,
+		// export_lc_expire_date,
 		up_date,
 		up_number,
 	} = lc;
@@ -194,12 +194,12 @@ export default function Information({ lc }) {
 					? format(new Date(export_lc_date), dateType)
 					: '',
 			},
-			{
-				label: 'Export Expire LC Date',
-				value: export_lc_expire_date
-					? format(new Date(export_lc_expire_date), dateType)
-					: '',
-			},
+			// {
+			// 	label: 'Export Expire LC Date',
+			// 	value: export_lc_expire_date
+			// 		? format(new Date(export_lc_expire_date), dateType)
+			// 		: '',
+			// },
 			{
 				label: 'Up Date',
 				value: up_date ? format(new Date(up_date), dateType) : '',

--- a/src/pages/Commercial/LC/Entry/Header.jsx
+++ b/src/pages/Commercial/LC/Entry/Header.jsx
@@ -53,7 +53,7 @@ export default function Header({
 	setDeleteLCEntryUD,
 }) {
 	const { lc_uuid } = useParams();
-	const { data: party } = useOtherParty();
+	const { data: party } = useOtherParty('&is_cash=false');
 
 	return (
 		<SectionEntryBody title='LC Information'>
@@ -162,13 +162,13 @@ export default function Header({
 						selected={watch('export_lc_date')}
 						{...{ register, errors }}
 					/>
-					<DateInput
+					{/* <DateInput
 						label='export_lc_expire_date'
 						Controller={Controller}
 						control={control}
 						selected={watch('export_lc_expire_date')}
 						{...{ register, errors }}
-					/>
+					/> */}
 					<DateInput
 						label='up_date'
 						Controller={Controller}
@@ -282,7 +282,8 @@ export default function Header({
 					<FormField
 						label='at_sight'
 						title='Payment Rec.'
-						errors={errors}>
+						errors={errors}
+					>
 						<Controller
 							name='at_sight'
 							control={control}

--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -2096,9 +2096,9 @@ export const LC_SCHEMA = {
 	// export
 	export_lc_number: STRING_REQUIRED,
 	export_lc_date: STRING_REQUIRED,
-	export_lc_expire_date: STRING_REQUIRED,
-	up_date: STRING_REQUIRED,
-	up_number: STRING_REQUIRED,
+	export_lc_expire_date: STRING.nullable(),
+	up_date: STRING.nullable(),
+	up_number: STRING.nullable(),
 
 	// if is_old_pi = true
 	pi_number: STRING.when('is_old_pi', {


### PR DESCRIPTION
Update the handling of export LC dates and modify the schema to allow nullable fields for certain date properties. This change improves data flexibility and aligns with the updated requirements.