### PR TITLE
Fix History bug in order details

### DIFF
--- a/src/pages/Order/Details/Entry/index.jsx
+++ b/src/pages/Order/Details/Entry/index.jsx
@@ -301,7 +301,11 @@ export default function Index() {
 					if (item.order_entry_uuid) {
 						await updateData.mutateAsync({
 							url: `/zipper/order-entry/${item.order_entry_uuid}`,
-							updatedData: { ...item, updated_at: GetDateTime() },
+							updatedData: {
+								...item,
+								updated_at: GetDateTime(),
+								created_by: user?.uuid,
+							},
 							isOnCloseNeeded: false,
 						});
 					} else {
@@ -313,6 +317,7 @@ export default function Index() {
 								order_description_uuid:
 									rest?.order_description_uuid,
 								created_at: GetDateTime(),
+								created_by: user?.uuid,
 							},
 							isOnCloseNeeded: false,
 						});

--- a/src/pages/Order/Details/_components/Table/Column.jsx
+++ b/src/pages/Order/Details/_components/Table/Column.jsx
@@ -269,9 +269,12 @@ const getColumn = ({
 			header: 'History',
 			enableColumnFilter: false,
 			hidden: !haveAccess.includes('show_history'),
-			cell: (info) => (
-				<EyeBtn onClick={() => handelHistory(info.row.index)} />
-			),
+			cell: (info) =>
+				info.row.original.history.length > 0 ? (
+					<EyeBtn onClick={() => handelHistory(info.row.index)} />
+				) : (
+					'---'
+				),
 		}),
 	];
 };

--- a/src/pages/Order/Details/_components/Table/History.jsx
+++ b/src/pages/Order/Details/_components/Table/History.jsx
@@ -1,20 +1,10 @@
 import { useMemo } from 'react';
-import { useOrderEntryHistory } from '@/state/Order';
 
 import { HistoryModal } from '@/components/Modal';
 import ReactTable from '@/components/Table';
 import { DateTime } from '@/ui';
 
-export default function Index({
-	modalId = '',
-	history = {
-		uuid: null,
-		order_entry_uuid: null,
-	},
-	setHistory,
-}) {
-	const { data, isLoading } = useOrderEntryHistory(history?.order_entry_uuid);
-
+export default function Index({ modalId = '', history = {}, setHistory }) {
 	const onClose = () => {
 		// document.getElementById(modalId).close();
 		window[modalId].close();
@@ -78,11 +68,8 @@ export default function Index({
 				cell: (info) => <DateTime date={info.getValue()} />,
 			},
 		],
-		[data]
+		[history?.history?.length]
 	);
-
-	if (isLoading)
-		return <span className='loading loading-dots loading-lg z-50' />;
 
 	return (
 		<HistoryModal
@@ -90,7 +77,11 @@ export default function Index({
 			title={modalId + ': History'}
 			onClose={onClose}
 		>
-			<ReactTable showTitleOnly={true} data={data} columns={columns} />
+			<ReactTable
+				showTitleOnly={true}
+				data={history?.history ?? []}
+				columns={columns}
+			/>
 		</HistoryModal>
 	);
 }

--- a/src/pages/Order/Details/_components/Table/index.jsx
+++ b/src/pages/Order/Details/_components/Table/index.jsx
@@ -117,7 +117,7 @@ export default function Index({
 					<td></td>
 				</tr>
 			</ReactTable>
-			{/* <Suspense>
+			<Suspense>
 				<History
 					modalId={title}
 					{...{
@@ -125,7 +125,7 @@ export default function Index({
 						setHistory,
 					}}
 				/>
-			</Suspense> */}
+			</Suspense>
 		</div>
 	);
 }


### PR DESCRIPTION
Resolve an issue where the history was not displayed correctly in order details. The changes ensure that the created_by field is populated and that the history is conditionally rendered.