### PR TITLE
Fix order PDF 2 bug

### DIFF
--- a/src/components/Pdf/OrderSheetByStyle/index.jsx
+++ b/src/components/Pdf/OrderSheetByStyle/index.jsx
@@ -288,7 +288,8 @@ export default function OrderSheetByStyle(orderByStyle) {
 														// 	bottom: 3,
 														// },
 														rowSpan:
-															1 +
+															entry.details
+																.length +
 															entry.details
 																.map(
 																	(detail) =>


### PR DESCRIPTION
Resolve an issue with the calculation of rowSpan in the order PDF, ensuring accurate rendering of details.