### PR TITLE
Fix PDF color total calculation in order sheet

### DIFF
--- a/src/components/Pdf/OrderSheetByStyle/index.jsx
+++ b/src/components/Pdf/OrderSheetByStyle/index.jsx
@@ -129,6 +129,33 @@ export default function OrderSheetByStyle(orderByStyle) {
 												total += size.quantity;
 												grandTotal += size.quantity;
 
+												const DetailsRowSpan =
+													entry.details
+														.map(
+															(detail) =>
+																detail.sizes
+																	.length
+														)
+														.reduce(
+															(acc, item) =>
+																acc + item,
+															0
+														);
+
+												const sizeRowSpan =
+													entry.details.reduce(
+														(acc, item) => {
+															if (
+																item.sizes
+																	.length > 1
+															) {
+																return acc + 1;
+															}
+															return acc;
+														},
+														0
+													);
+
 												return [
 													{
 														// * might need it later
@@ -288,24 +315,8 @@ export default function OrderSheetByStyle(orderByStyle) {
 														// 	bottom: 3,
 														// },
 														rowSpan:
-															entry.details
-																.length +
-															entry.details
-																.map(
-																	(detail) =>
-																		detail
-																			.sizes
-																			.length
-																)
-																.reduce(
-																	(
-																		acc,
-																		item
-																	) =>
-																		acc +
-																		item,
-																	0
-																),
+															sizeRowSpan +
+															DetailsRowSpan,
 													},
 													{
 														text: [
@@ -342,10 +353,11 @@ export default function OrderSheetByStyle(orderByStyle) {
 											}
 										);
 
-										// console.log([...detailsRow]);
 										return [
 											...detailsRow,
-											TotalColorQtyRow,
+											...(detail.sizes.length > 1
+												? [TotalColorQtyRow]
+												: []),
 										];
 									}
 								);


### PR DESCRIPTION
Correct the calculation of total colors in the order sheet by adjusting the row span logic for details and sizes. This ensures accurate totals are displayed in the generated PDF.