### PR TITLE
Fix cash bug in data display

### DIFF
--- a/src/pages/Commercial/Cash/index.jsx
+++ b/src/pages/Commercial/Cash/index.jsx
@@ -85,7 +85,8 @@ export default function Index() {
 					</>
 				),
 				enableColumnFilter: false,
-				cell: (info) => info.getValue().toLocaleString(),
+				cell: (info) =>
+					info.getValue() ? info.getValue().toLocaleString() : 0,
 			},
 			{
 				accessorKey: 'actions1',
@@ -110,7 +111,8 @@ export default function Index() {
 					</>
 				),
 				enableColumnFilter: false,
-				cell: (info) => info.getValue().toLocaleString(),
+				cell: (info) =>
+					info.getValue() ? info.getValue().toLocaleString() : 0,
 			},
 			{
 				accessorFn: (row) => {


### PR DESCRIPTION
Ensure that the cash value displays as 0 instead of undefined when no value is present.