### PR TITLE
Integrate user-specific path for fetching parties in production statements

### DIFF
--- a/src/pages/Report/ProductionStatement/order/Header.jsx
+++ b/src/pages/Report/ProductionStatement/order/Header.jsx
@@ -1,3 +1,4 @@
+import { useAuth } from '@/context/auth';
 import { useOtherMarketing, useOtherParty } from '@/state/Other';
 import { format } from 'date-fns';
 import { useAccess } from '@/hooks';
@@ -8,6 +9,14 @@ import {
 	SectionEntryBody,
 	SimpleDatePicker,
 } from '@/ui';
+
+const getPath = (haveAccess, userUUID) => {
+	if (haveAccess.includes('show_own_orders') && userUUID) {
+		return `own_uuid=${userUUID}`;
+	}
+
+	return ``;
+};
 
 export default function Header({
 	from = '',
@@ -22,8 +31,11 @@ export default function Header({
 	setType = () => {},
 }) {
 	const haveAccess = useAccess('report__production_statement');
+	const { user } = useAuth();
 	const { data: marketings } = useOtherMarketing();
-	const { data: parties } = useOtherParty();
+	const { data: parties } = useOtherParty(
+		`${getPath(haveAccess, user?.uuid) ? `${getPath(haveAccess, user?.uuid)}` : ''}`
+	);
 	const types = [
 		{ label: 'Nylon', value: 'nylon' },
 		{ label: 'Vislon', value: 'vislon' },

--- a/src/pages/Report/ProductionStatement/production/Header.jsx
+++ b/src/pages/Report/ProductionStatement/production/Header.jsx
@@ -44,7 +44,9 @@ export default function Header({
 	const { user } = useAuth();
 
 	const { data: marketings } = useOtherMarketing();
-	const { data: parties } = useOtherParty();
+	const { data: parties } = useOtherParty(
+		`${getPath(haveAccess, user?.uuid) ? `${getPath(haveAccess, user?.uuid)}` : ''}`
+	);
 	const { data: orders } = useAllZipperThreadOrderList(
 		`from_date=${format(from, 'yyyy-MM-dd')}&to_date=${format(to, 'yyyy-MM-dd')}&page=production_statement${reportFor === 'accounts' ? '_accounts' : ''}${getPath(haveAccess, user?.uuid) ? `&${getPath(haveAccess, user?.uuid)}` : ''}`
 	);


### PR DESCRIPTION
Implement a user-specific path for fetching parties in production statement headers based on user access rights. This change enhances data retrieval by ensuring users only access their own orders when applicable.