### PR TITLE
Add day range selection for dashboard order received

### DIFF
--- a/src/pages/Dashboard/_components/BarChartOverall/index.jsx
+++ b/src/pages/Dashboard/_components/BarChartOverall/index.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { format } from 'date-fns';
+import { format, subDays, subMonths } from 'date-fns';
 import numeral from 'numeral';
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
 
@@ -9,6 +9,7 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from '@/components/ui/chart';
+import { ReactSelect } from '@/ui';
 
 export const description = 'An interactive bar chart';
 
@@ -31,12 +32,20 @@ const chartConfig = {
 };
 
 export function BarChartOverall(
-	{ data } = {
+	{ data, setFrom, setTo } = {
 		data: [],
+		setFrom: () => {},
+		setTo: () => {},
 	}
 ) {
 	// var numeral = numeral();
 	const [activeChart, setActiveChart] = useState('zipper');
+	const [status, setStatus] = useState('30');
+	const options = [
+		{ value: 'all', label: 'All' },
+		{ value: '30', label: '30 days' },
+		{ value: '12', label: '12 months' },
+	];
 
 	const total = useMemo(
 		() => ({
@@ -50,8 +59,38 @@ export function BarChartOverall(
 		<Card>
 			<CardHeader className='flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row'>
 				<div className='flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6'>
-					<CardTitle className='text-3xl'>
-						Order Received (Last 30 days)
+					<CardTitle className='flex gap-4 text-3xl'>
+						Order Received{' '}
+						<ReactSelect
+							className='h-4 min-w-36 text-sm'
+							placeholder='Select Status'
+							options={options}
+							value={options?.filter(
+								(item) => item.value == status
+							)}
+							onChange={(e) => {
+								setStatus(e.value);
+								setTo(format(new Date(), 'yyyy-MM-dd'));
+								if (e.value === '30') {
+									setFrom(
+										format(
+											subDays(new Date(), 30),
+											'yyyy-MM-dd'
+										)
+									);
+								} else if (e.value === '12') {
+									setFrom(
+										format(
+											subMonths(new Date(), 12),
+											'yyyy-MM-dd'
+										)
+									);
+								} else {
+									setFrom('');
+									setTo('');
+								}
+							}}
+						/>
 					</CardTitle>
 				</div>
 				<div className='flex'>
@@ -118,16 +157,7 @@ export function BarChartOverall(
 									formatter={(value, name, item) => {
 										return (
 											<div className='grid min-w-[130px] grid-cols-2 items-center text-xs text-muted-foreground'>
-												<>
-													{chartConfig[name]?.label ||
-														name}
-												</>
-												<div className='ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-foreground'>
-													{numeral(value).format(
-														'0a'
-													)}
-												</div>
-												{name === 'zipper' && (
+												{name === 'zipper' ? (
 													<>
 														<div>Nylon</div>
 														<div className='ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-foreground'>
@@ -155,6 +185,24 @@ export function BarChartOverall(
 															{numeral(
 																item.payload
 																	.vislon
+															).format('0a')}
+														</div>
+														<div>Total</div>
+														<div className='ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-foreground'>
+															{numeral(
+																value
+															).format('0a')}
+														</div>
+													</>
+												) : (
+													<>
+														<div>
+															{chartConfig[name]
+																?.label || name}
+														</div>
+														<div className='ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-foreground'>
+															{numeral(
+																value
 															).format('0a')}
 														</div>
 													</>

--- a/src/pages/Dashboard/hooks/useDashboardData.js
+++ b/src/pages/Dashboard/hooks/useDashboardData.js
@@ -15,11 +15,11 @@ import {
 	useDashboardPaymentDue,
 } from '../query';
 
-const useDashboardData = (dataPreview) => {
+const useDashboardData = (dataPreview, from, to) => {
 	const { data: amount_and_doc, refetch: amountAndDocRefetch } =
 		useDashboardAmountAndDoc();
 	const { data: order_entry, refetch: orderEntryRefetch } =
-		useDashboardOrderEntry();
+		useDashboardOrderEntry(from, to);
 	const { data: payment_due, refetch: paymentDueRefetch } =
 		useDashboardPaymentDue();
 	const { data: acceptance_due, refetch: acceptanceDueRefetch } =

--- a/src/pages/Dashboard/index.jsx
+++ b/src/pages/Dashboard/index.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { BarChartHorizontal } from '@/pages/Dashboard/_components/BarChartHorizontal';
+import { format, subDays } from 'date-fns';
 
 import { BarChartHorizontal2 } from './_components/BarChartHorizontal2';
 import { BarChartOverall } from './_components/BarChartOverall';
@@ -21,13 +22,19 @@ import useDashboardData from './hooks/useDashboardData';
 
 export default function Dashboard() {
 	const [dataPreview, setDataPreview] = useState('real');
+
+	const [from, setFrom] = useState(
+		format(subDays(new Date(), 30), 'yyyy-MM-dd')
+	);
+	const [to, setTo] = useState(format(new Date(), 'yyyy-MM-dd'));
+
 	const {
 		amount_and_doc,
 		order_entry,
 		amount_percentage,
 		no_of_doc,
 		refreshAll,
-	} = useDashboardData(dataPreview);
+	} = useDashboardData(dataPreview, from, to);
 
 	useEffect(() => {
 		document.title = 'Dashboard';
@@ -42,7 +49,7 @@ export default function Dashboard() {
 			/>
 			<div className='space-y-2 px-2 py-2 lg:px-2'>
 				{/* Order Received */}
-				<BarChartOverall data={order_entry} />
+				<BarChartOverall data={order_entry} {...{ setFrom, setTo }} />
 				{/* Production: Demand */}
 				<div className='flex flex-col gap-2 md:flex-row'>
 					<BarChartHorizontal2 />

--- a/src/pages/Dashboard/query/index.js
+++ b/src/pages/Dashboard/query/index.js
@@ -3,11 +3,13 @@ import createGlobalState from '@/state';
 import { dashboardQK } from './queryKeys';
 
 // Dashboard Order Entry
-export const useDashboardOrderEntry = () =>
-	createGlobalState({
-		queryKey: dashboardQK.order_entry(),
-		url: '/dashboard/order-entry',
+export const useDashboardOrderEntry = (from, to) => {
+	console.log(from, to);
+	return createGlobalState({
+		queryKey: dashboardQK.order_entry(from, to),
+		url: `/dashboard/order-entry?from=${from}&to=${to}`,
 	});
+};
 
 // Dashboard Amount and Doc
 export const useDashboardAmountAndDoc = () =>

--- a/src/pages/Dashboard/query/queryKeys.js
+++ b/src/pages/Dashboard/query/queryKeys.js
@@ -1,7 +1,7 @@
 export const dashboardQK = {
 	all: () => ['dashboard'],
 
-	order_entry: () => [...dashboardQK.all(), 'order-entry'],
+	order_entry: (from, to) => [...dashboardQK.all(), 'order-entry', from, to],
 
 	amount_and_doc: () => [...dashboardQK.all(), 'amount-and-doc'],
 	amount_percentage: () => [...dashboardQK.all(), 'amount-percentage'],


### PR DESCRIPTION
Introduce a day range selector for the order received chart, allowing users to filter data by the last 30 days or the last 12 months. Update the dashboard data fetching to accommodate the selected date range.