### PR TITLE
Fix URL construction for order details

### DIFF
--- a/src/pages/Report/OrderSummary/TransposedTable.jsx
+++ b/src/pages/Report/OrderSummary/TransposedTable.jsx
@@ -168,7 +168,7 @@ export default function TransposedTable({ data, transformedData }) {
 						item?.order_description_uuid ? (
 							<CustomLink
 								label={item?.item_description}
-								url={`/order/details/${item?.order_number}/${item?.order_description_uuid}`}
+								url={`/order/details/${data?.order_number}/${item?.order_description_uuid}`}
 								openInNewTab={true}
 							/>
 						) : (


### PR DESCRIPTION
Correct the URL used for linking to order details to ensure it references the correct order number.