### PR TITLE
Correct factory name to party name in proforma invoice header

### DIFF
--- a/src/components/Pdf/ManualProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ManualProformaInvoice/utils.jsx
@@ -56,13 +56,13 @@ export const getPageHeader = (data) => {
 			// * Start of table
 			[
 				{ text: 'Proforma For:', bold: true, color: PRIMARY_COLOR },
-				data?.party_name,
+				data?.factory_name,
 				{ text: 'Advising Bank:', bold: true, color: PRIMARY_COLOR },
 				data?.bank_name,
 			],
 			[
 				{ text: 'Address', bold: true, color: PRIMARY_COLOR },
-				{ text: data?.party_address },
+				{ text: data?.factory_address },
 
 				{ text: 'Address', bold: true, color: PRIMARY_COLOR },
 				{ text: data?.bank_address },

--- a/src/components/Pdf/ManualProformaInvoice/utils.jsx
+++ b/src/components/Pdf/ManualProformaInvoice/utils.jsx
@@ -56,7 +56,7 @@ export const getPageHeader = (data) => {
 			// * Start of table
 			[
 				{ text: 'Proforma For:', bold: true, color: PRIMARY_COLOR },
-				data?.factory_name,
+				data?.party_name,
 				{ text: 'Advising Bank:', bold: true, color: PRIMARY_COLOR },
 				data?.bank_name,
 			],


### PR DESCRIPTION
Update the proforma invoice header to display the party name instead of the factory name.