### PR TITLE
Fix row filtering logic for order number in thread data

### DIFF
--- a/src/components/Pdf/ManualProformaInvoice/index.jsx
+++ b/src/components/Pdf/ManualProformaInvoice/index.jsx
@@ -109,8 +109,9 @@ export default function Index(data) {
 	});
 	const thread = sortedThreadData.map((item) => {
 		const rowSpan = sortedThreadData.filter(
-			(data) => data.order === item.order
+			(data) => data.order_number === item.order_number
 		).length;
+		console.log('rowSpan', rowSpan);
 		const sizeRowSpan = sortedThreadData.filter(
 			(data) =>
 				data.size === item.size &&

--- a/src/components/Pdf/ThreadPackeListStickerV2/index.jsx
+++ b/src/components/Pdf/ThreadPackeListStickerV2/index.jsx
@@ -124,8 +124,8 @@ export default function Index(data) {
 				layout: {
 					hLineWidth: () => 0,
 					vLineWidth: () => 0,
-					paddingLeft: () => 0,
-					paddingRight: () => 0,
+					paddingLeft: () => 1,
+					paddingRight: () => 1,
 					paddingTop: () => 2,
 					paddingBottom: () => 2,
 				},

--- a/src/components/Pdf/ThreadPackeListStickerV2/index.jsx
+++ b/src/components/Pdf/ThreadPackeListStickerV2/index.jsx
@@ -58,7 +58,7 @@ export default function Index(data) {
 			},
 			{
 				table: {
-					widths: [17, 30, 90, 50],
+					widths: [17, 30, 100, 55],
 					body: [
 						[
 							{
@@ -121,7 +121,14 @@ export default function Index(data) {
 						],
 					],
 				},
-				layout: 'noBorders',
+				layout: {
+					hLineWidth: () => 0,
+					vLineWidth: () => 0,
+					paddingLeft: () => 0,
+					paddingRight: () => 0,
+					paddingTop: () => 2,
+					paddingBottom: () => 2,
+				},
 			}
 		);
 


### PR DESCRIPTION
Update the row filtering logic to use the correct property for order number in thread data. This change ensures accurate filtering based on the intended property.