### PR TITLE
Add lab/recipe filter functionality

### DIFF
--- a/src/pages/LabDip/Recipe/index.jsx
+++ b/src/pages/LabDip/Recipe/index.jsx
@@ -1,16 +1,25 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLabDipRecipe } from '@/state/LabDip';
 import { useNavigate } from 'react-router-dom';
 import { useAccess } from '@/hooks';
 
 import ReactTable from '@/components/Table';
-import { DateTime, EditDelete, LinkWithCopy } from '@/ui';
+import { DateTime, EditDelete, LinkWithCopy, StatusSelect } from '@/ui';
 
 import GetDateTime from '@/util/GetDateTime';
 import PageInfo from '@/util/PageInfo';
 
 export default function Index() {
-	const { data, isLoading, isError, url, updateData } = useLabDipRecipe();
+	const [status, setStatus] = useState('bulk');
+	const options = [
+		{ label: 'TXP', value: 'txp' },
+		{ label: 'SSP', value: 'ssp' },
+		{ label: 'ZS', value: 'zipper_sample' },
+		{ label: 'Bulk ', value: 'bulk' },
+		{ label: 'Others', value: 'others' },
+	];
+	const { data, isLoading, isError, url, updateData } =
+		useLabDipRecipe(status);
 	const navigate = useNavigate();
 	const info = new PageInfo('Lab Dip/Recipe', url, 'lab_dip__recipe');
 	const haveAccess = useAccess('lab_dip__recipe');
@@ -147,6 +156,13 @@ export default function Index() {
 				data={data}
 				columns={columns}
 				handelAdd={handelAdd}
+				extraButton={
+					<StatusSelect
+						status={status}
+						setStatus={setStatus}
+						options={options}
+					/>
+				}
 			/>
 		</div>
 	);

--- a/src/state/LabDip.jsx
+++ b/src/state/LabDip.jsx
@@ -7,10 +7,10 @@ export const useLabDipDashboard = () =>
 		queryKey: labDipQK.dashboard(),
 		url: '/lab-dip/info-recipe-dashboard',
 	});
-export const useLabDipRecipe = () =>
+export const useLabDipRecipe = (status) =>
 	createGlobalState({
-		queryKey: labDipQK.recipe(),
-		url: '/lab-dip/recipe',
+		queryKey: labDipQK.recipe(status),
+		url: `/lab-dip/recipe?type=${status}`,
 	});
 
 export const useLabDipRecipeByUUID = (uuid) =>

--- a/src/state/QueryKeys.jsx
+++ b/src/state/QueryKeys.jsx
@@ -382,7 +382,7 @@ export const labDipQK = {
 	//* dashboard
 	dashboard: () => [...labDipQK.all(), 'dashboard'],
 	//* recipe
-	recipe: () => [...labDipQK.all(), 'recipe'],
+	recipe: (status) => [...labDipQK.all(), 'recipe', status],
 	recipeByUUID: (uuid) => [...labDipQK.recipe(), uuid],
 	recipeDetailsByUUID: (uuid) => [...labDipQK.recipe(), 'details', uuid],
 


### PR DESCRIPTION
Introduce a status filter for lab dip recipes, allowing users to filter by different recipe types. Update the related hooks and query keys to accommodate the new filtering feature.