### PR TITLE
Add new order filter for lab-dip zipper and thread

### DIFF
--- a/src/pages/LabDip/ThreadSwatch/index.jsx
+++ b/src/pages/LabDip/ThreadSwatch/index.jsx
@@ -18,13 +18,23 @@ import PageInfo from '@/util/PageInfo';
 
 export default function Index() {
 	const [status, setStatus] = useState('pending');
+	const [status2, setStatus2] = useState('incomplete_order');
 	const options = [
 		{ value: 'all', label: 'All' },
 		{ value: 'pending', label: 'Pending' },
 		{ value: 'completed', label: 'Completed' },
 	];
 
-	const { data, updateData, isLoading } = useThreadSwatch(`type=${status}`);
+	const options2 = [
+		{ value: 'complete_order', label: 'Complete Order' },
+		{ value: 'incomplete_order', label: 'Incomplete Order' },
+	];
+
+	const { data, updateData, isLoading } = useThreadSwatch(
+		status2 === 'complete_order'
+			? `order_type=${status2}`
+			: `type=${status}&order_type=${status2}`
+	);
 	const info = new PageInfo(
 		'LabDip/Thread Swatch',
 		'order/swatch',
@@ -212,11 +222,20 @@ export default function Index() {
 				data={data}
 				columns={columns}
 				extraButton={
-					<StatusSelect
-						options={options}
-						status={status}
-						setStatus={setStatus}
-					/>
+					<>
+						{status2 === 'incomplete_order' && (
+							<StatusSelect
+								options={options}
+								status={status}
+								setStatus={setStatus}
+							/>
+						)}
+						<StatusSelect
+							options={options2}
+							status={status2}
+							setStatus={setStatus2}
+						/>
+					</>
 				}
 			/>
 		</div>

--- a/src/pages/LabDip/ZipperSwatch/index.jsx
+++ b/src/pages/LabDip/ZipperSwatch/index.jsx
@@ -18,12 +18,21 @@ import PageInfo from '@/util/PageInfo';
 
 export default function Index() {
 	const [status, setStatus] = useState('pending');
+	const [status2, setStatus2] = useState('incomplete_order');
 	const options = [
 		{ value: 'all', label: 'All' },
 		{ value: 'pending', label: 'Pending' },
 		{ value: 'completed', label: 'Completed' },
 	];
-	const { data, isLoading } = useDyeingSwatch(`type=${status}`);
+	const options2 = [
+		{ value: 'complete_order', label: 'Complete Order' },
+		{ value: 'incomplete_order', label: 'Incomplete Order' },
+	];
+	const { data, isLoading } = useDyeingSwatch(
+		status2 === 'complete_order'
+			? `order_type=${status2}`
+			: `type=${status}&order_type=${status2}`
+	);
 	const { updateData } = useDyeingDummy();
 	const info = new PageInfo(
 		'LabDip/ZipperSwatch',
@@ -238,11 +247,20 @@ export default function Index() {
 				data={data}
 				columns={columns}
 				extraButton={
-					<StatusSelect
-						options={options}
-						status={status}
-						setStatus={setStatus}
-					/>
+					<>
+						{status2 === 'incomplete_order' && (
+							<StatusSelect
+								options={options}
+								status={status}
+								setStatus={setStatus}
+							/>
+						)}
+						<StatusSelect
+							options={options2}
+							status={status2}
+							setStatus={setStatus2}
+						/>
+					</>
 				}
 			/>
 		</div>


### PR DESCRIPTION
Introduce a new order filter for lab-dip zipper and thread components, allowing users to select between complete and incomplete orders. This enhances the filtering capabilities of the application.