### PR TITLE
Add 'Sample' column with StatusButton in Warehouse logs

### DIFF
--- a/src/pages/Delivery/Log/WarehouseNotOut/index.jsx
+++ b/src/pages/Delivery/Log/WarehouseNotOut/index.jsx
@@ -5,7 +5,13 @@ import { format } from 'date-fns';
 import { useAccess } from '@/hooks';
 
 import ReactTable from '@/components/Table';
-import { CustomLink, DateTime, LinkWithCopy, SimpleDatePicker } from '@/ui';
+import {
+	CustomLink,
+	DateTime,
+	LinkWithCopy,
+	SimpleDatePicker,
+	StatusButton,
+} from '@/ui';
 
 import PageInfo from '@/util/PageInfo';
 
@@ -192,6 +198,14 @@ export default function Index() {
 				header: 'Weight',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'is_sample',
+				header: 'Sample',
+				enableColumnFilter: false,
+				cell: (info) => (
+					<StatusButton size='btn-sm' value={info.getValue()} />
+				),
 			},
 			{
 				accessorKey: 'count',

--- a/src/pages/Delivery/Log/WarehouseOut/index.jsx
+++ b/src/pages/Delivery/Log/WarehouseOut/index.jsx
@@ -5,7 +5,13 @@ import { format } from 'date-fns';
 import { useAccess } from '@/hooks';
 
 import ReactTable from '@/components/Table';
-import { CustomLink, DateTime, LinkWithCopy, SimpleDatePicker } from '@/ui';
+import {
+	CustomLink,
+	DateTime,
+	LinkWithCopy,
+	SimpleDatePicker,
+	StatusButton,
+} from '@/ui';
 
 import PageInfo from '@/util/PageInfo';
 
@@ -231,7 +237,14 @@ export default function Index() {
 					return `${packing_list_wise_rank}/${packing_list_wise_count}`;
 				},
 			},
-
+			{
+				accessorKey: 'is_sample',
+				header: 'Sample',
+				enableColumnFilter: false,
+				cell: (info) => (
+					<StatusButton size='btn-sm' value={info.getValue()} />
+				),
+			},
 			{
 				accessorKey: 'created_by_name',
 				header: 'Created By',

--- a/src/pages/Delivery/Log/WarehouseRCV/index.jsx
+++ b/src/pages/Delivery/Log/WarehouseRCV/index.jsx
@@ -5,7 +5,13 @@ import { format } from 'date-fns';
 import { useAccess } from '@/hooks';
 
 import ReactTable from '@/components/Table';
-import { CustomLink, DateTime, LinkWithCopy, SimpleDatePicker } from '@/ui';
+import {
+	CustomLink,
+	DateTime,
+	LinkWithCopy,
+	SimpleDatePicker,
+	StatusButton,
+} from '@/ui';
 
 import PageInfo from '@/util/PageInfo';
 
@@ -222,7 +228,14 @@ export default function Index() {
 					return `${packing_list_wise_rank}/${packing_list_wise_count}`;
 				},
 			},
-
+			{
+				accessorKey: 'is_sample',
+				header: 'Sample',
+				enableColumnFilter: false,
+				cell: (info) => (
+					<StatusButton size='btn-sm' value={info.getValue()} />
+				),
+			},
 			{
 				accessorKey: 'created_by_name',
 				header: 'Created By',

--- a/src/state/Store.jsx
+++ b/src/state/Store.jsx
@@ -63,9 +63,14 @@ export const useMaterialTrxByUUID = (uuid) =>
 export const useMaterialBooking = (type, from, to) =>
 	createGlobalState({
 		queryKey: materialQK.booking(type, from, to),
-		url: type
-			? `/material/booking?s_type=${type}&from_date=${from}&to_date=${to}`
-			: `/material/booking?from_date=${from}&to_date=${to}`,
+		url:
+			type && from && to
+				? `/material/booking?s_type=${type}&from_date=${from}&to_date=${to}`
+				: type
+					? `/material/booking?s_type=${type}`
+					: from && to
+						? `/material/booking?from_date=${from}&to_date=${to}`
+						: '/material/booking',
 	});
 
 export const useMaterialBookingByUUID = (uuid) =>


### PR DESCRIPTION
Introduce a new 'Sample' column in the WarehouseNotOut and WarehouseRCV logs, utilizing the StatusButton component for better visual representation of sample status.