### PR TITLE
Add finishing balance calculation and display in order details

### DIFF
--- a/src/pages/Delivery/PackingList/Entry/index.jsx
+++ b/src/pages/Delivery/PackingList/Entry/index.jsx
@@ -85,6 +85,14 @@ export default function Index() {
 	);
 
 	useEffect(() => {
+		if (isUpdate && details?.is_warehouse_received) {
+			ShowLocalToast({
+				type: 'error',
+				message: 'Packing List is already received',
+			});
+			navigate(`/delivery/packing-list/${details?.uuid}`);
+		}
+
 		if (!isUpdate && packingListEntries?.packing_list_entry) {
 			setValue(
 				'packing_list_entry',
@@ -107,6 +115,14 @@ export default function Index() {
 
 	// Submit
 	const onSubmit = async (data) => {
+		if (isUpdate && data?.is_warehouse_received) {
+			ShowLocalToast({
+				type: 'error',
+				message: 'Packing List is already received',
+			});
+			return;
+		}
+
 		if (
 			data?.new_packing_list_entry?.some(
 				(item) =>

--- a/src/pages/Order/Details/ByOrderDescriptionUUID/index.jsx
+++ b/src/pages/Order/Details/ByOrderDescriptionUUID/index.jsx
@@ -120,6 +120,7 @@ export default function Index({ initial_order, idx }) {
 				parseFloat(item.total_warehouse_quantity) || 0;
 			totals.rejectQuantity +=
 				parseFloat(item.total_reject_quantity) || 0;
+			totals.finishingBalance += parseFloat(item.finishing_balance) || 0;
 			totals.shortQuantity += parseFloat(item.total_short_quantity) || 0;
 			totals.tapeQuantity += parseFloat(item.dying_and_iron_prod) || 0;
 			totals.sliderQuantity += parseFloat(item.coloring_prod) || 0;
@@ -147,6 +148,7 @@ export default function Index({ initial_order, idx }) {
 			deliveryQuantity: 0,
 			warehouseQuantity: 0,
 			rejectQuantity: 0,
+			finishingBalance: 0,
 			shortQuantity: 0,
 			tapeQuantity: 0,
 			sliderQuantity: 0,

--- a/src/pages/Order/Details/_components/Table/index.jsx
+++ b/src/pages/Order/Details/_components/Table/index.jsx
@@ -25,6 +25,8 @@ export default function Index({
 }) {
 	const haveAccess = useAccess('order__details');
 
+	console.log('total', total);
+
 	const [history, setHistory] = useState(null);
 	let title = item_description;
 
@@ -108,7 +110,7 @@ export default function Index({
 						<td className='px-3 py-1'>{total.sliderQuantity}</td>
 					)}
 					{!is_sample && <td colSpan={colspan}></td>}
-					<td></td>
+					<td className='px-3 py-1'>{total.finishingBalance}</td>
 					<td className='px-3 py-1'>{total.warehouseQuantity}</td>
 					<td className='px-3 py-1'>{total.deliveryQuantity}</td>
 


### PR DESCRIPTION
Implement finishing balance calculation and display it in the order details table. Additionally, handle cases where the packing list is already received to prevent further updates.