### PR TITLE
Add O/N column delivery and packing list percentage to Index page

### DIFF
--- a/src/components/Pdf/OrderSheet/utils.jsx
+++ b/src/components/Pdf/OrderSheet/utils.jsx
@@ -22,6 +22,16 @@ const renderCashOrLC = (is_cash, is_sample, is_bill, is_only_value) => {
 export const getPageHeader = (order_info) => {
 	const haveAccess = useAccess('order__details');
 
+	let formatedDate = '';
+	if (order_info?.order_description_updated_at) {
+		formatedDate = format(
+			new Date(order_info?.order_description_updated_at),
+			'dd-MM-yyyy'
+		);
+	} else if (order_info?.created_at) {
+		formatedDate = format(new Date(order_info?.created_at), 'dd-MM-yyyy');
+	}
+
 	const order_number =
 		order_info.is_sample === 1
 			? order_info.order_number + ' (S)'
@@ -66,7 +76,7 @@ export const getPageHeader = (order_info) => {
 						bold: true,
 					},
 					`O/N: ${order_number} ${order_info.revisions > 0 ? `Rev ${order_info.revisions}` : ''} \n`,
-					`Date: ${order_info?.created_at ? format(new Date(order_info?.created_at), 'dd-MM-yyyy') : ''}\n`,
+					`Date: ${formatedDate}\n`,
 					`PI No.: ${order_info?.pi_numbers ? order_info?.pi_numbers.join(', ') : '---'}\n`,
 				],
 				alignment: 'right',

--- a/src/components/Pdf/OrderSheetByStyle/utils.jsx
+++ b/src/components/Pdf/OrderSheetByStyle/utils.jsx
@@ -19,6 +19,7 @@ export const getPageHeader = (order_info) => {
 	} else if (order_info?.created_at) {
 		formatedDate = format(new Date(order_info?.created_at), 'dd-MM-yyyy');
 	}
+	console.log(order_info?.order_description_updated_at);
 	return [
 		// CompanyAndORDER
 		[

--- a/src/pages/Commercial/PI/index.jsx
+++ b/src/pages/Commercial/PI/index.jsx
@@ -169,7 +169,7 @@ export default function Index() {
 												(item.delivered /
 													item.quantity) *
 													100 || 0
-											).toFixed(1)}{' '}
+											).toFixed(0)}
 											%
 										</td>
 										<td>
@@ -177,7 +177,7 @@ export default function Index() {
 												(item.packing_list /
 													item.quantity) *
 													100 || 0
-											).toFixed(1)}{' '}
+											).toFixed(0)}
 											%
 										</td>
 									</tr>

--- a/src/pages/Commercial/PI/index.jsx
+++ b/src/pages/Commercial/PI/index.jsx
@@ -8,6 +8,7 @@ import { DeleteModal } from '@/components/Modal';
 import ReactTable from '@/components/Table';
 import { CustomLink, DateTime, EditDelete, StatusSelect } from '@/ui';
 
+import { cn } from '@/lib/utils';
 import PageInfo from '@/util/PageInfo';
 
 const getPath = (haveAccess, userUUID) => {
@@ -109,9 +110,9 @@ export default function Index() {
 				id: 'order_numbers',
 				header: 'O/N',
 				enableColumnFilter: false,
-				cell: ({ row }) => {
+				cell: (info) => {
 					const { order_numbers, thread_order_numbers } =
-						row.original;
+						info.row.original;
 
 					let links = [];
 
@@ -119,6 +120,9 @@ export default function Index() {
 						.filter((order) => order.order_info_uuid)
 						.forEach((order) => {
 							links.push({
+								quantity: order.quantity,
+								delivered: order.delivered,
+								packing_list: order.packing_list,
 								label: order.order_number,
 								url: `/order/details/${order.order_number}`,
 							});
@@ -128,18 +132,59 @@ export default function Index() {
 						.filter((order) => order.thread_order_info_uuid)
 						.forEach((order) => {
 							links.push({
+								quantity: order.quantity,
+								delivered: order.delivered,
+								packing_list: order.packing_list,
 								label: order.thread_order_number,
 								url: `/thread/order-info/${order.thread_order_info_uuid}`,
 							});
 						});
 
-					return links.map((link, index) => (
-						<CustomLink
-							key={index}
-							label={link.label}
-							url={link.url}
-						/>
-					));
+					return (
+						<table
+							className={cn(
+								'table table-xs rounded-md border-2 border-primary/20 align-top'
+							)}
+						>
+							<thead>
+								<tr>
+									<th>O/N</th>
+									<th>D/Q</th>
+									<th>P/Q</th>
+								</tr>
+							</thead>
+							<tbody>
+								{links?.map((item, index) => (
+									<tr key={index}>
+										<td>
+											<CustomLink
+												label={item.label}
+												url={item.url}
+												showCopyButton={false}
+												openInNewTab
+											/>
+										</td>
+										<td>
+											{Number(
+												(item.delivered /
+													item.quantity) *
+													100 || 0
+											).toFixed(1)}{' '}
+											%
+										</td>
+										<td>
+											{Number(
+												(item.packing_list /
+													item.quantity) *
+													100 || 0
+											).toFixed(1)}{' '}
+											%
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					);
 				},
 			},
 			{


### PR DESCRIPTION
Introduce an O/N column to display order numbers along with delivery and packing list percentages in a tabular format on the Index page. This enhances the visibility of order-related metrics.