### PR TITLE
Fix date reference in getPageHeader function

### DIFF
--- a/src/components/Pdf/OrderSheet/utils.jsx
+++ b/src/components/Pdf/OrderSheet/utils.jsx
@@ -23,9 +23,9 @@ export const getPageHeader = (order_info) => {
 	const haveAccess = useAccess('order__details');
 
 	let formatedDate = '';
-	if (order_info?.order_description_updated_at) {
+	if (order_info?.order_description_created_at) {
 		formatedDate = format(
-			new Date(order_info?.order_description_updated_at),
+			new Date(order_info?.order_description_created_at),
 			'dd-MM-yyyy'
 		);
 	} else if (order_info?.created_at) {

--- a/src/components/Pdf/OrderSheetByStyle/utils.jsx
+++ b/src/components/Pdf/OrderSheetByStyle/utils.jsx
@@ -11,15 +11,15 @@ export const getPageHeader = (order_info) => {
 			: order_info.order_number;
 
 	let formatedDate = '';
-	if (order_info?.order_description_updated_at) {
+	if (order_info?.order_description_created_at) {
 		formatedDate = format(
-			new Date(order_info?.order_description_updated_at),
+			new Date(order_info?.order_description_created_at),
 			'dd-MM-yyyy'
 		);
 	} else if (order_info?.created_at) {
 		formatedDate = format(new Date(order_info?.created_at), 'dd-MM-yyyy');
 	}
-	console.log(order_info?.order_description_updated_at);
+	console.log(order_info?.order_description_created_at);
 	return [
 		// CompanyAndORDER
 		[


### PR DESCRIPTION
Update the date reference in the getPageHeader function to use `order_description_created_at` instead of `order_description_updated_at`. This change ensures the correct date is displayed.