### PR TITLE
Add optional chaining to prevent errors accessing order properties

### DIFF
--- a/src/pages/Commercial/PI/index.jsx
+++ b/src/pages/Commercial/PI/index.jsx
@@ -91,19 +91,19 @@ export default function Index() {
 					const { order_numbers, thread_order_numbers } = row;
 					const zipper =
 						order_numbers
-							.map((order) => order.order_number)
-							.join(', ') || '';
+							?.map((order) => order?.order_number)
+							?.join(', ') || '';
 					const thread =
 						thread_order_numbers
-							.map((order) => order.thread_order_number)
-							.join(', ') || '';
+							?.map((order) => order?.thread_order_number)
+							?.join(', ') || '';
 
-					if (zipper.length > 0 && thread.length > 0)
+					if (zipper?.length > 0 && thread?.length > 0)
 						return `${zipper}, ${thread}`;
 
-					if (zipper.length > 0) return zipper;
+					if (zipper?.length > 0) return zipper;
 
-					if (thread.length > 0) return thread;
+					if (thread?.length > 0) return thread;
 
 					return '--';
 				},
@@ -117,8 +117,8 @@ export default function Index() {
 					let links = [];
 
 					order_numbers
-						.filter((order) => order.order_info_uuid)
-						.forEach((order) => {
+						?.filter((order) => order.order_info_uuid)
+						?.forEach((order) => {
 							links.push({
 								quantity: order.quantity,
 								delivered: order.delivered,
@@ -129,8 +129,8 @@ export default function Index() {
 						});
 
 					thread_order_numbers
-						.filter((order) => order.thread_order_info_uuid)
-						.forEach((order) => {
+						?.filter((order) => order.thread_order_info_uuid)
+						?.forEach((order) => {
 							links.push({
 								quantity: order.quantity,
 								delivered: order.delivered,
@@ -188,7 +188,7 @@ export default function Index() {
 				},
 			},
 			{
-				accessorFn: (row) => row.order_type.join(', ') || '--',
+				accessorFn: (row) => row?.order_type?.join(', ') || '--',
 				id: 'order_type',
 				header: 'Type',
 				enableColumnFilter: false,


### PR DESCRIPTION
Optional chaining has been implemented to enhance error handling when accessing properties of order objects, ensuring that the application does not crash due to undefined values.