### PR TITLE
Add sample/bulk filter to delivery logs

### DIFF
--- a/src/pages/Delivery/Log/WarehouseNotOut/index.jsx
+++ b/src/pages/Delivery/Log/WarehouseNotOut/index.jsx
@@ -11,6 +11,7 @@ import {
 	LinkWithCopy,
 	SimpleDatePicker,
 	StatusButton,
+	StatusSelect,
 } from '@/ui';
 
 import PageInfo from '@/util/PageInfo';
@@ -26,12 +27,19 @@ const getPath = (haveAccess, userUUID) => {
 export default function Index() {
 	const [from, setFrom] = useState(new Date());
 	const [to, setTo] = useState(new Date());
+	const [status, setStatus] = useState('0');
+	// * options for extra select in table
+	const options = [
+		{ value: '0', label: 'Bulk' },
+		{ value: '1', label: 'Sample' },
+	];
 
 	const haveAccess = useAccess('delivery__warehouse_out');
 	const { user } = useAuth();
 	const { data, isLoading, url } = useWarehouseNotOutLog(
 		format(from, 'yyyy-MM-dd'),
 		format(to, 'yyyy-MM-dd'),
+		status,
 		{
 			enabled: true,
 		}
@@ -299,6 +307,11 @@ export default function Index() {
 							setTo(data);
 						}}
 						selected={to}
+					/>
+					<StatusSelect
+						status={status}
+						setStatus={setStatus}
+						options={options}
 					/>
 				</div>
 			}

--- a/src/pages/Delivery/Log/WarehouseOut/index.jsx
+++ b/src/pages/Delivery/Log/WarehouseOut/index.jsx
@@ -11,6 +11,7 @@ import {
 	LinkWithCopy,
 	SimpleDatePicker,
 	StatusButton,
+	StatusSelect,
 } from '@/ui';
 
 import PageInfo from '@/util/PageInfo';
@@ -26,12 +27,19 @@ const getPath = (haveAccess, userUUID) => {
 export default function Index() {
 	const [from, setFrom] = useState(new Date());
 	const [to, setTo] = useState(new Date());
+	const [status, setStatus] = useState('0');
+	// * options for extra select in table
+	const options = [
+		{ value: '0', label: 'Bulk' },
+		{ value: '1', label: 'Sample' },
+	];
 
 	const haveAccess = useAccess('delivery__warehouse_out');
 	const { user } = useAuth();
 	const { data, isLoading, url } = useWarehouseOutLog(
 		format(from, 'yyyy-MM-dd'),
 		format(to, 'yyyy-MM-dd'),
+		status,
 		{
 			enabled: true,
 		}
@@ -325,6 +333,11 @@ export default function Index() {
 							setTo(data);
 						}}
 						selected={to}
+					/>{' '}
+					<StatusSelect
+						status={status}
+						setStatus={setStatus}
+						options={options}
 					/>
 				</div>
 			}

--- a/src/pages/Delivery/Log/WarehouseRCV/index.jsx
+++ b/src/pages/Delivery/Log/WarehouseRCV/index.jsx
@@ -11,6 +11,7 @@ import {
 	LinkWithCopy,
 	SimpleDatePicker,
 	StatusButton,
+	StatusSelect,
 } from '@/ui';
 
 import PageInfo from '@/util/PageInfo';
@@ -18,10 +19,18 @@ import PageInfo from '@/util/PageInfo';
 export default function Index() {
 	const [from, setFrom] = useState(new Date());
 	const [to, setTo] = useState(new Date());
+	const [status, setStatus] = useState('0');
+	// * options for extra select in table
+	const options = [
+		{ value: '0', label: 'Bulk' },
+		{ value: '1', label: 'Sample' },
+	];
+
 	const { user } = useAuth();
 	const { data, isLoading, url } = useWarehouseRcvLog(
 		format(from, 'yyyy-MM-dd'),
 		format(to, 'yyyy-MM-dd'),
+		status,
 		{
 			enabled: true,
 		}
@@ -316,6 +325,11 @@ export default function Index() {
 							setTo(data);
 						}}
 						selected={to}
+					/>
+					<StatusSelect
+						status={status}
+						setStatus={setStatus}
+						options={options}
 					/>
 				</div>
 			}

--- a/src/state/Delivery.jsx
+++ b/src/state/Delivery.jsx
@@ -202,11 +202,12 @@ export const useOrderAgainstDeliveryRMLogByUUID = (uuid) =>
 export const useWarehouseRcvLog = (
 	from,
 	to,
+	status,
 	{ enabled = false } = { enabled: false }
 ) =>
 	createGlobalState({
-		queryKey: deliveryQk.warehouseRcvLog(from, to),
-		url: `/delivery/packing-list-received-log?from=${from}&to=${to}`,
+		queryKey: deliveryQk.warehouseRcvLog(from, to, status),
+		url: `/delivery/packing-list-received-log?from=${from}&to=${to}&is_sample=${status}`,
 		enabled,
 	});
 
@@ -214,11 +215,12 @@ export const useWarehouseRcvLog = (
 export const useWarehouseOutLog = (
 	from,
 	to,
+	status,
 	{ enabled = false } = { enabled: false }
 ) =>
 	createGlobalState({
-		queryKey: deliveryQk.warehouseOutLog(from, to),
-		url: `/delivery/packing-list-warehouse-out-log?from=${from}&to=${to}`,
+		queryKey: deliveryQk.warehouseOutLog(from, to, status),
+		url: `/delivery/packing-list-warehouse-out-log?from=${from}&to=${to}&is_sample=${status}`,
 		enabled,
 	});
 
@@ -227,11 +229,12 @@ export const useWarehouseOutLog = (
 export const useWarehouseNotOutLog = (
 	from,
 	to,
+	status,
 	{ enabled = false } = { enabled: false }
 ) =>
 	createGlobalState({
-		queryKey: deliveryQk.warehouseNotOutLog(from, to),
-		url: `/delivery/packing-list-received-warehouse-notout-log?from=${from}&to=${to}`,
+		queryKey: deliveryQk.warehouseNotOutLog(from, to, status),
+		url: `/delivery/packing-list-received-warehouse-notout-log?from=${from}&to=${to}&is_sample=${status}`,
 		enabled,
 	});
 

--- a/src/state/QueryKeys.jsx
+++ b/src/state/QueryKeys.jsx
@@ -1168,23 +1168,26 @@ export const deliveryQk = {
 		uuid,
 	],
 	//* Warehouse Rcv Log
-	warehouseRcvLog: (from, to) => [
+	warehouseRcvLog: (from, to, status) => [
 		...deliveryQk.all(),
 		'warehouse-rcv-log',
 		from,
 		to,
+		status,
 	],
-	warehouseOutLog: (from, to) => [
+	warehouseOutLog: (from, to, status) => [
 		...deliveryQk.all(),
 		'warehouse-out-log',
 		from,
 		to,
+		status,
 	],
-	warehouseNotOutLog: (from, to) => [
+	warehouseNotOutLog: (from, to, status) => [
 		...deliveryQk.all(),
 		'warehouse-not-out-log',
 		from,
 		to,
+		status,
 	],
 	deliveryReturnQuantity: (query) => [
 		...deliveryQk.all(),


### PR DESCRIPTION
Introduce a status selection feature for filtering delivery logs by sample or bulk. Update relevant hooks and query keys to accommodate the new filtering option.