### PR TITLE
Handle empty newEntry and newOrder cases in postData mutation

### DIFF
--- a/src/pages/Order/Details/Entry/index.jsx
+++ b/src/pages/Order/Details/Entry/index.jsx
@@ -324,13 +324,14 @@ export default function Index() {
 				});
 			});
 
-			const newOrderEntryPromise = newOrder?.map(async (item) => {
-				await postData.mutateAsync({
-					url: '/zipper/order-entry',
-					newData: item,
-					isOnCloseNeeded: false,
-				});
-			});
+			const newOrderEntryPromise =
+				newOrder.length > 0
+					? await postData.mutateAsync({
+							url: '/zipper/order-entry',
+							newData: newOrder,
+							isOnCloseNeeded: false,
+						})
+					: null;
 
 			// swatchInvalidate();
 

--- a/src/pages/Thread/Order/Entry/index.jsx
+++ b/src/pages/Thread/Order/Entry/index.jsx
@@ -187,11 +187,14 @@ export default function Index() {
 				});
 			});
 
-			const entryCreatePromise = await postData.mutateAsync({
-				url: threadOrderEntryUrl,
-				newData: newEntry,
-				isOnCloseNeeded: false,
-			});
+			const entryCreatePromise =
+				newEntry.length > 0
+					? await postData.mutateAsync({
+							url: threadOrderEntryUrl,
+							newData: newEntry,
+							isOnCloseNeeded: false,
+						})
+					: null;
 
 			try {
 				await Promise.all([


### PR DESCRIPTION
Ensure that the postData mutation handles cases where newEntry and newOrder are empty, preventing unnecessary requests.