### PR TITLE
Add time formatting utility and update date display in OrderStatus table

### DIFF
--- a/src/pages/Report/OrderStatus/Zipper.jsx
+++ b/src/pages/Report/OrderStatus/Zipper.jsx
@@ -7,7 +7,7 @@ import { useAccess } from '@/hooks';
 import ReactTable from '@/components/Table';
 import { CustomLink, DateTime, SimpleDatePicker } from '@/ui';
 
-import { REPORT_DATE_FORMATE } from '../utils';
+import { REPORT_DATE_FORMATE, REPORT_DATE_TIME_FORMAT } from '../utils';
 
 const getPath = (haveAccess, userUUID) => {
 	if (haveAccess.includes('show_own_orders') && userUUID) {
@@ -251,30 +251,14 @@ export default function Index() {
 			},
 			{
 				accessorFn: (row) =>
-					row.batch_number &&
-					REPORT_DATE_FORMATE(row.batch_created_at),
+					row.batch_created_at &&
+					REPORT_DATE_TIME_FORMAT(row.batch_created_at),
 				id: 'batch_created_at',
 				header: 'B/D',
 				enableColumnFilter: false,
 				cell: (info) => (
 					<DateTime
 						date={info.row.original.batch_created_at}
-						isTime={false}
-						customizedDateFormate='dd MMM,yyyy'
-					/>
-				),
-			},
-			{
-				accessorFn: (row) =>
-					row.production_date &&
-					REPORT_DATE_FORMATE(row.production_date),
-				id: 'production_date',
-				header: 'P/D',
-				enableColumnFilter: false,
-				cell: (info) => (
-					<DateTime
-						date={info.row.original.production_date}
-						isTime={false}
 						customizedDateFormate='dd MMM,yyyy'
 					/>
 				),
@@ -290,6 +274,21 @@ export default function Index() {
 				header: 'B/Kg',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
+			},
+			{
+				accessorFn: (row) =>
+					row.production_date &&
+					REPORT_DATE_FORMATE(row.production_date),
+				id: 'production_date',
+				header: 'P/D',
+				enableColumnFilter: false,
+				cell: (info) => (
+					<DateTime
+						date={info.row.original.production_date}
+						isTime={false}
+						customizedDateFormate='dd MMM,yyyy'
+					/>
+				),
 			},
 			{
 				accessorKey: 'batch_expected_kg',

--- a/src/pages/Report/utils.jsx
+++ b/src/pages/Report/utils.jsx
@@ -72,3 +72,6 @@ export const consumptionTypes = [
 ];
 
 export const REPORT_DATE_FORMATE = (date) => format(date, 'dd-MMM-yyyy');
+
+export const REPORT_DATE_TIME_FORMAT = (date) =>
+	format(date, 'dd-MMM-yyyy HH:mm:ss');


### PR DESCRIPTION
Introduce a new utility for time formatting and update the date display in the OrderStatus table to include time. This enhances the clarity of date information presented to users.