### PR TITLE
Fix LC number mapping in Thread and Zipper components

### DIFF
--- a/src/pages/Report/OrderStatus/Thread.jsx
+++ b/src/pages/Report/OrderStatus/Thread.jsx
@@ -87,7 +87,7 @@ export default function Index() {
 						? row.lc_numbers
 						: [];
 					if (lcArr.length === 0) return '--';
-					return lcArr.map((pi) => pi.pi_number).join(', ');
+					return lcArr.map((lc) => lc.lc_numbers).join(', ');
 				},
 				id: 'lc_numbers',
 				header: <>LC No.</>,
@@ -97,11 +97,11 @@ export default function Index() {
 						? info.row.original.lc_numbers
 						: [];
 					if (lcArr.length === 0) return '--';
-					return lcArr.map((pi) => (
+					return lcArr.map((lc) => (
 						<CustomLink
-							key={pi.pi_number}
-							label={pi.pi_number}
-							url={`/commercial/pi/${pi.pi_number}`}
+							key={lc.lc_number}
+							label={lc.lc_number}
+							url={`/commercial/lc/details/${lc.lc_uuid}`}
 							openInNewTab
 						/>
 					));

--- a/src/pages/Report/OrderStatus/Zipper.jsx
+++ b/src/pages/Report/OrderStatus/Zipper.jsx
@@ -124,7 +124,7 @@ export default function Index() {
 						? row.lc_numbers
 						: [];
 					if (lcArr.length === 0) return '--';
-					return lcArr.map((pi) => pi.lc_numbers).join(', ');
+					return lcArr.map((lc) => lc.lc_numbers).join(', ');
 				},
 				id: 'lc_numbers',
 				header: <>LC No.</>,


### PR DESCRIPTION
Correct the mapping of LC numbers in the Thread and Zipper components to ensure accurate data display. This change enhances the representation of LC numbers in the user interface.