### PR TITLE
Add 'Warehouse QTY' column to Order Status table and clean up useThreadStatus hook

### DIFF
--- a/src/pages/Report/OrderStatusThread/Thread.jsx
+++ b/src/pages/Report/OrderStatusThread/Thread.jsx
@@ -24,7 +24,7 @@ export default function Index() {
 	const [date, setDate] = useState(new Date());
 	const [toDate, setToDate] = useState(new Date());
 
-	const { data, isLoading, url } = useThreadStatus(
+	const { data, isLoading } = useThreadStatus(
 		format(date, 'yyyy-MM-dd'),
 		format(toDate, 'yyyy-MM-dd'),
 		getPath(haveAccess, user?.uuid),
@@ -271,6 +271,12 @@ export default function Index() {
 			{
 				accessorKey: 'total_coning_production_quantity',
 				header: 'Coning QTY',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'warehouse',
+				header: 'Warehouse QTY',
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},


### PR DESCRIPTION
Introduce a new column for 'Warehouse QTY' in the Order Status table and remove an unused URL from the useThreadStatus hook.