### PR TITLE
Add color_ref to PDF and labdip exports

### DIFF
--- a/src/components/Pdf/OrderSheet/index.jsx
+++ b/src/components/Pdf/OrderSheet/index.jsx
@@ -66,7 +66,7 @@ export default function OrderSheetPdf(order_sheet) {
 				].sort((a, b) => a - b);
 				const res = order_entry.reduce((acc, item) => {
 					const key = item.style;
-					const color = item.color;
+					const color = item.color + ' - ' + item.color_ref;
 					const size = Number(item.size);
 					const quantity = Number(item.quantity);
 					const bleach = item.bleaching;
@@ -101,7 +101,7 @@ export default function OrderSheetPdf(order_sheet) {
 
 					return acc;
 				}, {});
-
+				console.log(res);
 				//todo: order_type condition will start from here
 				if (entry.order_type !== 'slider') {
 					// * garments info
@@ -152,7 +152,7 @@ export default function OrderSheetPdf(order_sheet) {
 													// * the bleaching status for each quantity
 													const bleaching =
 														color.bleach;
-
+													// console.log(color.color_ref);
 													// * Slicing the quantities array for each chunk
 													const slicedQuantities =
 														quantities.slice(

--- a/src/components/Pdf/ThreadOrderSheet/index.jsx
+++ b/src/components/Pdf/ThreadOrderSheet/index.jsx
@@ -86,9 +86,17 @@ export default function Index(orderInfo) {
 						TableHeader(node),
 
 						// * Body
-						...order_info_entry?.map((item) =>
+						...(Array.isArray(order_info_entry)
+							? order_info_entry
+							: []
+						).map((item) =>
 							node.map((nodeItem) => ({
-								text: item[nodeItem.field],
+								text:
+									nodeItem.field === 'color'
+										? item[nodeItem.field] +
+											' - ' +
+											item.color_ref
+										: item[nodeItem.field],
 								style: nodeItem.cellStyle,
 								alignment: nodeItem.alignment,
 							}))

--- a/src/pages/LabDip/ThreadSwatch/index.jsx
+++ b/src/pages/LabDip/ThreadSwatch/index.jsx
@@ -75,7 +75,40 @@ export default function Index() {
 				width: 'w-24',
 				cell: (info) => info.getValue(),
 			},
-
+			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				width: 'w-24',
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
 			{
 				accessorKey: 'count_length_name',
 				header: 'Count Length',

--- a/src/pages/LabDip/ZipperSwatch/index.jsx
+++ b/src/pages/LabDip/ZipperSwatch/index.jsx
@@ -113,6 +113,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				// enableColumnFilter: true,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'size',
 				header: 'Size',
 				width: 'w-24',

--- a/src/pages/Thread/Order/Details/index.jsx
+++ b/src/pages/Thread/Order/Details/index.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useThreadDetailsByUUID } from '@/state/Thread';
 import OrderSheetPdf from '@components/Pdf/ThreadOrderSheet';
 import { Navigate, useParams } from 'react-router';
-import { useFetchFunc } from '@/hooks';
 
 import Information from './Information';
 import Table from './Table';

--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -2584,7 +2584,7 @@ export const THREAD_ORDER_INFO_ENTRY_SCHEMA = {
 		yup.object().shape({
 			index: NUMBER_REQUIRED,
 			color: STRING_REQUIRED,
-			color_ref: STRING,
+			color_ref: STRING.nullable(),
 			// shade_recipe_uuid: STRING.nullable(),
 			// po: STRING_REQUIRED,
 			style: STRING_REQUIRED,


### PR DESCRIPTION
Enhance the order sheet PDF and labdip components by incorporating the color_ref attribute, improving the representation of color information in the output.