### PR TITLE
Fix date parameter naming in daily challan report query

### DIFF
--- a/src/pages/DyeingAndIron/ThreadBatch/index.jsx
+++ b/src/pages/DyeingAndIron/ThreadBatch/index.jsx
@@ -124,6 +124,12 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorFn: (row) => row.recipe_name.join(', '),
 				id: 'recipe_name',
 				header: 'Shade',

--- a/src/pages/DyeingAndIron/ZipperBatch/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/index.jsx
@@ -136,6 +136,12 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorKey: 'total_quantity',
 				header: (
 					<>

--- a/src/pages/LabDip/Info/index.jsx
+++ b/src/pages/LabDip/Info/index.jsx
@@ -78,6 +78,12 @@ export default function Index() {
 				width: 'w-32',
 				cell: (info) => info.getValue(),
 			},
+			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
 			// {
 			// 	accessorFn: (row) => {
 			// 		return row.recipe_array

--- a/src/pages/LabDip/ThreadSwatch/index.jsx
+++ b/src/pages/LabDip/ThreadSwatch/index.jsx
@@ -82,34 +82,6 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
-				accessorKey: 'color_ref_entry_date',
-				header: (
-					<>
-						Color Ref <br /> Entry
-					</>
-				),
-				filterFn: 'isWithinRange',
-				enableColumnFilter: false,
-				width: 'w-24',
-				cell: (info) => {
-					return <DateTime date={info.getValue()} />;
-				},
-			},
-			{
-				accessorKey: 'color_ref_update_date',
-				header: (
-					<>
-						Color Ref <br /> Update
-					</>
-				),
-				filterFn: 'isWithinRange',
-				enableColumnFilter: false,
-				width: 'w-24',
-				cell: (info) => {
-					return <DateTime date={info.getValue()} />;
-				},
-			},
-			{
 				accessorKey: 'count_length_name',
 				header: 'Count Length',
 				width: 'w-24',
@@ -237,6 +209,34 @@ export default function Index() {
 				cell: (info) => (
 					<DateTime date={info.row.original.swatch_approval_date} />
 				),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
 			},
 		],
 		[data, shade_recipe, haveAccess]

--- a/src/pages/LabDip/ZipperSwatch/index.jsx
+++ b/src/pages/LabDip/ZipperSwatch/index.jsx
@@ -119,34 +119,6 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
-				accessorKey: 'color_ref_entry_date',
-				header: (
-					<>
-						Color Ref <br /> Entry
-					</>
-				),
-				filterFn: 'isWithinRange',
-				enableColumnFilter: false,
-				width: 'w-24',
-				cell: (info) => {
-					return <DateTime date={info.getValue()} />;
-				},
-			},
-			{
-				accessorKey: 'color_ref_update_date',
-				header: (
-					<>
-						Color Ref <br /> Update
-					</>
-				),
-				filterFn: 'isWithinRange',
-				enableColumnFilter: false,
-				width: 'w-24',
-				cell: (info) => {
-					return <DateTime date={info.getValue()} />;
-				},
-			},
-			{
 				accessorKey: 'size',
 				header: 'Size',
 				width: 'w-24',
@@ -282,6 +254,34 @@ export default function Index() {
 				cell: (info) => (
 					<DateTime date={info.row.original.swatch_approval_date} />
 				),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
 			},
 		],
 		[data, recipe, handleSwatchStatus, haveAccess]

--- a/src/pages/Planning/ApprovalDate/index.jsx
+++ b/src/pages/Planning/ApprovalDate/index.jsx
@@ -108,6 +108,12 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				// enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorKey: 'size',
 				header: 'Size',
 				width: 'w-24',

--- a/src/pages/Planning/Overview/index.jsx
+++ b/src/pages/Planning/Overview/index.jsx
@@ -81,6 +81,12 @@ export default function index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
 				accessorFn: (row) =>
 					row.order_type == 'slider' ? '--' : row.recipe_id,
 				id: 'recipe_id',

--- a/src/pages/Report/Bulk/index.jsx
+++ b/src/pages/Report/Bulk/index.jsx
@@ -154,6 +154,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'size',
 				header: 'Size',
 				enableColumnFilter: false,

--- a/src/pages/Report/DeliveryReport/Thread.jsx
+++ b/src/pages/Report/DeliveryReport/Thread.jsx
@@ -150,6 +150,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'item_description',
 				header: 'Count Length',
 				enableColumnFilter: false,

--- a/src/pages/Report/DeliveryReport/Zipper.jsx
+++ b/src/pages/Report/DeliveryReport/Zipper.jsx
@@ -167,6 +167,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'size',
 				header: 'Size',
 				enableColumnFilter: false,

--- a/src/pages/Report/OrderTracking/index.jsx
+++ b/src/pages/Report/OrderTracking/index.jsx
@@ -235,6 +235,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'size',
 				header: 'Size',
 				enableColumnFilter: false,

--- a/src/pages/Report/PackingList/index.jsx
+++ b/src/pages/Report/PackingList/index.jsx
@@ -188,6 +188,40 @@ export default function Index() {
 				cell: (info) => info.getValue().join(', '),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'unit',
 				header: 'Unit',
 				enableColumnFilter: false,

--- a/src/pages/Report/Sample/index.jsx
+++ b/src/pages/Report/Sample/index.jsx
@@ -155,6 +155,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'size',
 				header: 'Size',
 				enableColumnFilter: false,

--- a/src/pages/Report/ThreadBatch/index.jsx
+++ b/src/pages/Report/ThreadBatch/index.jsx
@@ -125,6 +125,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorFn: (row) => row.recipe_name.join(', '),
 				id: 'recipe_name',
 				header: 'Shade',

--- a/src/pages/Report/ThreadProductionStatus/thread-production.jsx
+++ b/src/pages/Report/ThreadProductionStatus/thread-production.jsx
@@ -148,6 +148,40 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorKey: 'recipe_name',
 				header: 'Shade',
 				width: 'w-24',

--- a/src/pages/Report/ThreadProductionStatusOrderWise/index.jsx
+++ b/src/pages/Report/ThreadProductionStatusOrderWise/index.jsx
@@ -125,6 +125,40 @@ export default function Index() {
 				enableColumnFilter: false,
 			},
 			{
+				accessorKey: 'color_ref',
+				header: 'Color Ref',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
+			{
+				accessorKey: 'color_ref_entry_date',
+				header: (
+					<>
+						Color Ref <br /> Entry
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
+				accessorKey: 'color_ref_update_date',
+				header: (
+					<>
+						Color Ref <br /> Update
+					</>
+				),
+				filterFn: 'isWithinRange',
+				enableColumnFilter: false,
+				width: 'w-24',
+				cell: (info) => {
+					return <DateTime date={info.getValue()} />;
+				},
+			},
+			{
 				accessorFn: (row) => {
 					return row.thread_batch
 						?.map((item) => item.finishing_batch_number)

--- a/src/state/Report.jsx
+++ b/src/state/Report.jsx
@@ -111,8 +111,8 @@ export const useDailyChallan = (from, to, query, { enabled = false } = {}) =>
 	createGlobalState({
 		queryKey: reportQK.dailyChallan(from, to, query),
 		url: query
-			? `/report/daily-challan-report?from=${from}&to=${to}&${query}`
-			: `/report/daily-challan-report?from=${from}&to=${to}`,
+			? `/report/daily-challan-report?from_date=${from}&to_date=${to}&${query}`
+			: `/report/daily-challan-report?from_date=${from}&to_date=${to}`,
 		enabled,
 	});
 


### PR DESCRIPTION
Update the query parameters in the daily challan report to use `from_date` and `to_date` for consistency.