### PR TITLE
Make merchandiser_uuid nullable in MANUAL_PI_SCHEMA

### DIFF
--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -2312,7 +2312,7 @@ export const MANUAL_PI_SCHEMA = {
 	marketing_uuid: STRING_REQUIRED,
 	party_uuid: STRING_REQUIRED,
 	buyer_uuid: STRING_REQUIRED,
-	merchandiser_uuid: STRING_REQUIRED,
+	merchandiser_uuid: STRING.nullable(),
 	factory_uuid: STRING_REQUIRED,
 	bank_uuid: STRING_REQUIRED,
 	validity: NUMBER_REQUIRED,


### PR DESCRIPTION
Update the MANUAL_PI_SCHEMA to allow merchandiser_uuid to be nullable, enhancing flexibility in data handling.