### PR TITLE
Enhance PDF viewer accessibility in iframes

### DIFF
--- a/src/pages/Delivery/PackingList/Details/index.jsx
+++ b/src/pages/Delivery/PackingList/Details/index.jsx
@@ -68,13 +68,19 @@ export default function Index() {
 					{data?.item_for === 'thread' ||
 					data?.item_for === 'sample_thread' ? (
 						<iframe
-							src={data4}
+							src={`${data4}#toolbar=1&navpanes=1&scrollbar=1&view=FitH`}
 							className='h-[20rem] w-full rounded-md border-none'
+							title='Packing List PDF'
+							allow='fullscreen'
+							sandbox='allow-same-origin allow-scripts allow-popups allow-forms'
 						/>
 					) : (
 						<iframe
-							src={data3}
+							src={`${data3}#toolbar=1&navpanes=1&scrollbar=1&view=FitH`}
 							className='h-[20rem] w-full rounded-md border-none'
+							title='Packing List PDF'
+							allow='fullscreen'
+							sandbox='allow-same-origin allow-scripts allow-popups allow-forms'
 						/>
 					)}
 				</div>


### PR DESCRIPTION
Update iframe `src` attributes to include PDF viewer parameters and improve accessibility features such as titles and sandboxing.