### PR TITLE
Fix spelling of 'cancelled' in InfoColumns

### DIFF
--- a/src/pages/Order/columns.jsx
+++ b/src/pages/Order/columns.jsx
@@ -378,7 +378,7 @@ export const InfoColumns = ({
 				},
 			},
 			{
-				accessorFn: (row) => (row.is_canceled ? 'YES' : 'NO'),
+				accessorFn: (row) => (row.is_cancelled ? 'YES' : 'NO'),
 				id: 'is_cancelled',
 				header: 'Cancelled',
 				enableColumnFilter: false,
@@ -386,7 +386,7 @@ export const InfoColumns = ({
 				cell: (info) => (
 					<StatusButton
 						size='btn-xs'
-						value={info.row.original.is_canceled}
+						value={info.row.original.is_cancelled}
 					/>
 				),
 			},


### PR DESCRIPTION
Corrected the spelling of 'cancelled' in the InfoColumns component to ensure consistency and accuracy.