### PR TITLE
Add filter for sample type in dyeing dashboard

### DIFF
--- a/src/pages/DyeingAndIron/DyeingDashboard/Header.jsx
+++ b/src/pages/DyeingAndIron/DyeingDashboard/Header.jsx
@@ -10,13 +10,20 @@ export default function Header({
 	setMachines,
 	orderType,
 	setOrderType,
+	isSample,
+	setIsSample,
 }) {
 	const { data: machineOptions } = useOtherMachines();
 
 	const orderTypes = [
-		{ label: 'Bulk', value: 'bulk' },
-		{ label: 'Sample', value: 'sample' },
+		{ label: 'Zipper', value: 'zipper' },
+		{ label: 'Thread', value: 'thread' },
 		{ label: 'All', value: 'all' },
+	];
+	const sampleTypes = [
+		{ label: 'Bulk', value: 0 },
+		{ label: 'Sample', value: 1 },
+		{ label: 'All', value: 2 },
 	];
 	return (
 		<div>
@@ -50,6 +57,18 @@ export default function Header({
 						)}
 						onChange={(e) => {
 							setOrderType(e.value);
+						}}
+						menuPortalTarget={document.body}
+					/>
+					<ReactSelect
+						className='md:min-w-96'
+						placeholder='Select Sample Type'
+						options={sampleTypes}
+						value={sampleTypes?.find(
+							(item) => item.value == isSample
+						)}
+						onChange={(e) => {
+							setIsSample(e.value);
 						}}
 						menuPortalTarget={document.body}
 					/>

--- a/src/pages/DyeingAndIron/DyeingDashboard/index.jsx
+++ b/src/pages/DyeingAndIron/DyeingDashboard/index.jsx
@@ -14,6 +14,7 @@ import Header from './Header';
 export default function index() {
 	const [machines, setMachines] = useState([]);
 	const [orderType, setOrderType] = useState('all');
+	const [isSample, setIsSample] = useState(2);
 
 	const haveAccess = useAccess('dyeing__dyeing_dashboard');
 
@@ -26,7 +27,7 @@ export default function index() {
 	const [dyeingDate, setDyeingDate] = useState(
 		format(new Date(), 'yyyy-MM-dd')
 	);
-	const { data } = useDyeingDashboard(dyeingDate, orderType);
+	const { data } = useDyeingDashboard(dyeingDate, orderType, isSample);
 
 	useEffect(() => {
 		document.title = info.getTabName();
@@ -69,6 +70,8 @@ export default function index() {
 					setMachines,
 					orderType,
 					setOrderType,
+					isSample,
+					setIsSample,
 				}}
 			/>
 			<Content data={data} dyeingDate={dyeingDate} />

--- a/src/state/Dyeing.jsx
+++ b/src/state/Dyeing.jsx
@@ -227,10 +227,10 @@ export const useDyeingFinishingBatchOrders = (uuid) =>
 	});
 
 // * Dyeing Dashboard
-export const useDyeingDashboard = (param, orderType) =>
+export const useDyeingDashboard = (param, orderType, isSample) =>
 	createGlobalState({
-		queryKey: dyeingQK.dyeingDashboard(param, orderType),
-		url: `/public/machine/by/${param}?order_type=${orderType}`,
+		queryKey: dyeingQK.dyeingDashboard(param, orderType, isSample),
+		url: `/public/machine/by/${param}?order_type=${orderType}&is_sample=${isSample}`,
 	});
 
 // * Finishing Dashboard

--- a/src/state/QueryKeys.jsx
+++ b/src/state/QueryKeys.jsx
@@ -585,11 +585,12 @@ export const dyeingQK = {
 	],
 
 	//* Dyeing Dashboard
-	dyeingDashboard: (param, orderType) => [
+	dyeingDashboard: (param, orderType, isSample) => [
 		...dyeingQK.all(),
 		'dyeing-dashboard',
 		param,
 		orderType,
+		isSample,
 	],
 
 	//* Finishing Dashboard


### PR DESCRIPTION
Introduce a new filter for sample types in the dyeing dashboard, allowing users to select between different sample categories. Update relevant components and hooks to accommodate this new functionality.