### PR TITLE
Add 'Damaged' column to ThreadBatch and Order details tables

### DIFF
--- a/src/pages/DyeingAndIron/ThreadBatch/Details/Table.jsx
+++ b/src/pages/DyeingAndIron/ThreadBatch/Details/Table.jsx
@@ -101,7 +101,12 @@ export default function Index({ batch_entry }) {
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
-
+			{
+				accessorKey: 'damaged_quantity',
+				header: 'Damaged',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
 			{
 				accessorKey: 'batch_remarks',
 				header: 'Remarks',

--- a/src/pages/Thread/Order/Details/Table/index.jsx
+++ b/src/pages/Thread/Order/Details/Table/index.jsx
@@ -153,6 +153,12 @@ export default function Index({ order_info_entry }) {
 				enableColumnFilter: false,
 				cell: (info) => info.getValue(),
 			},
+			{
+				accessorKey: 'damage_quantity',
+				header: 'Damaged',
+				enableColumnFilter: false,
+				cell: (info) => info.getValue(),
+			},
 
 			...(useAccess('thread__order_info_details').includes('show_price')
 				? [


### PR DESCRIPTION
Introduce a new 'Damaged' column in both the ThreadBatch and Order details tables to track damaged quantities.