### PR TITLE
Add optional chaining for safer order and thread mappings

### DIFF
--- a/src/pages/Commercial/Cash/index.jsx
+++ b/src/pages/Commercial/Cash/index.jsx
@@ -119,12 +119,12 @@ export default function Index() {
 					const { order_numbers, thread_order_numbers } = row;
 					const zipper =
 						order_numbers
-							.map((order) => order.order_number)
-							.join(', ') || '';
+							?.map((order) => order.order_number)
+							?.join(', ') || '';
 					const thread =
 						thread_order_numbers
-							.map((order) => order.thread_order_number)
-							.join(', ') || '';
+							?.map((order) => order.thread_order_number)
+							?.join(', ') || '';
 
 					if (zipper.length > 0 && thread.length > 0)
 						return `${zipper}, ${thread}`;
@@ -145,8 +145,8 @@ export default function Index() {
 					let links = [];
 
 					order_numbers
-						.filter((order) => order.order_info_uuid)
-						.forEach((order) => {
+						?.filter((order) => order.order_info_uuid)
+						?.forEach((order) => {
 							links.push({
 								label: order.order_number,
 								url: `/order/details/${order.order_number}`,
@@ -154,8 +154,8 @@ export default function Index() {
 						});
 
 					thread_order_numbers
-						.filter((order) => order.thread_order_info_uuid)
-						.forEach((order) => {
+						?.filter((order) => order.thread_order_info_uuid)
+						?.forEach((order) => {
 							links.push({
 								label: order.thread_order_number,
 								url: `/thread/order-info/${order.thread_order_info_uuid}`,
@@ -172,7 +172,7 @@ export default function Index() {
 				},
 			},
 			{
-				accessorFn: (row) => row.order_type.join(', ') || '--',
+				accessorFn: (row) => row.order_type?.join(', ') || '--',
 				id: 'order_type',
 				header: 'Type',
 				enableColumnFilter: false,

--- a/src/pages/Planning/ApprovalDate/index.jsx
+++ b/src/pages/Planning/ApprovalDate/index.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useAuth } from '@/context/auth';
 import { usePlanningApprovalDate } from '@/state/Planning';
 import { format } from 'date-fns';
 import { useAccess } from '@/hooks';
@@ -24,6 +25,7 @@ const options2 = [
 export default function Index() {
 	const [status, setStatus] = useState('pending');
 	const [status2, setStatus2] = useState('incomplete_order');
+	const { user } = useAuth();
 
 	const { data, isLoading, updateData } = usePlanningApprovalDate(
 		status2 === 'complete_order'
@@ -45,6 +47,7 @@ export default function Index() {
 				bulk_approval_date: data[idx]?.bulk_approval
 					? null
 					: GetDateTime(),
+				bulk_approval_by: user?.uuid,
 				updated_at: GetDateTime(),
 			},
 			isOnCloseNeeded: false,


### PR DESCRIPTION
Implement optional chaining to prevent errors when accessing order and thread number mappings, enhancing the robustness of the code.