### PR TITLE
Display bulk approval name in the approval date section

### DIFF
--- a/src/pages/Planning/ApprovalDate/index.jsx
+++ b/src/pages/Planning/ApprovalDate/index.jsx
@@ -215,6 +215,9 @@ export default function Index() {
 							checked={info.row.original.bulk_approval === true}
 						/>
 						<DateTime date={info.row.original.bulk_approval_date} />
+						<span className='text-xs text-gray-500'>
+							{info.row.original.bulk_approval_by_name}
+						</span>
 					</div>
 				),
 			},


### PR DESCRIPTION
Show the name of the user who initiated the bulk approval in the approval date section for better clarity.