### PR TITLE
Fix item_descriptions bug in zipper/batch processing

### DIFF
--- a/src/pages/DyeingAndIron/ZipperBatch/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/index.jsx
@@ -93,7 +93,12 @@ export default function Index() {
 				},
 			},
 			{
-				accessorKey: 'item_descriptions',
+				accessorFn: (row) => {
+					return row.item_descriptions
+						?.map((item) => item.item_description)
+						.join(', ');
+				},
+				id: 'item_descriptions',
 				header: 'Item Description',
 				// enableColumnFilter: true,
 				cell: (info) => {


### PR DESCRIPTION
Resolve an issue with the item_descriptions field by modifying the accessor function to correctly format the item descriptions for display.