### PR TITLE
Add status date and batch status date to dyeing zipper/thread

### DIFF
--- a/src/pages/DyeingAndIron/ThreadBatch/Dyeing/Entry/index.jsx
+++ b/src/pages/DyeingAndIron/ThreadBatch/Dyeing/Entry/index.jsx
@@ -93,6 +93,7 @@ export default function Index() {
 			...data,
 			[isCreatedAtNull ? 'dyeing_created_at' : 'dyeing_updated_at']:
 				GetDateTime(),
+			status_date: data?.status !== 'pending' ? GetDateTime() : null,
 			yarn_issue_created_by: user.uuid,
 			yarn_issue_created_at: GetDateTime(),
 		};

--- a/src/pages/DyeingAndIron/ThreadBatch/index.jsx
+++ b/src/pages/DyeingAndIron/ThreadBatch/index.jsx
@@ -197,14 +197,20 @@ export default function Index() {
 						pending: 'badge-warning',
 					};
 					return (
-						<span
-							className={cn(
-								'badge badge-sm uppercase',
-								res[info.getValue()]
-							)}
-						>
-							{info.getValue()}
-						</span>
+						<div className='flex flex-col gap-1'>
+							<span
+								className={cn(
+									'badge badge-sm uppercase',
+									res[info.getValue()]
+								)}
+							>
+								{info.getValue()}
+							</span>
+							<DateTime
+								date={info.row.original.status_date}
+								isTime={false}
+							/>
+						</div>
 					);
 				},
 			},
@@ -233,16 +239,23 @@ export default function Index() {
 						}
 					}
 					return (
-						<SwitchToggle
-							disabled={isDisabled}
-							onChange={() =>
-								handelDryingComplete(info.row.index)
-							}
-							checked={info.getValue() === 'true'}
-						/>
+						<div className='flex flex-col gap-1'>
+							<SwitchToggle
+								disabled={isDisabled}
+								onChange={() =>
+									handelDryingComplete(info.row.index)
+								}
+								checked={info.getValue() === 'true'}
+							/>
+							<DateTime
+								date={info.row.original.drying_created_at}
+								isTime={false}
+							/>
+						</div>
 					);
 				},
 			},
+
 			{
 				accessorKey: 'machine_name',
 				header: 'Machine',

--- a/src/pages/DyeingAndIron/ZipperBatch/Production/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/Production/index.jsx
@@ -100,6 +100,8 @@ export default function Index() {
 				machine_uuid: data.machine_uuid,
 				slot: data.slot,
 				batch_status: data.batch_status,
+				batch_status_date:
+					data?.batch_status !== 'pending' ? GetDateTime() : null,
 				updated_at: GetDateTime(),
 			},
 			isOnCloseNeeded: false,

--- a/src/pages/DyeingAndIron/ZipperBatch/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/index.jsx
@@ -262,14 +262,20 @@ export default function Index() {
 						pending: 'badge-warning',
 					};
 					return (
-						<span
-							className={cn(
-								'badge badge-sm uppercase',
-								res[info.getValue()]
-							)}
-						>
-							{info.getValue()}
-						</span>
+						<div className='flex flex-col gap-1'>
+							<span
+								className={cn(
+									'badge badge-sm uppercase',
+									res[info.getValue()]
+								)}
+							>
+								{info.getValue()}
+							</span>
+							<DateTime
+								date={info.row.original.batch_status_date}
+								isTime={false}
+							/>
+						</div>
 					);
 				},
 			},
@@ -300,25 +306,18 @@ export default function Index() {
 						}
 					}
 					return (
-						<SwitchToggle
-							disabled={isDisabled}
-							onChange={() => handelReceived(info.row.index)}
-							checked={info.getValue() === 1}
-						/>
+						<div className='flex flex-col gap-1'>
+							<SwitchToggle
+								disabled={isDisabled}
+								onChange={() => handelReceived(info.row.index)}
+								checked={info.getValue() === 1}
+							/>
+							<DateTime
+								date={info.row.original.received_date}
+								isTime={false}
+							/>
+						</div>
 					);
-				},
-			},
-			{
-				accessorKey: 'received_date',
-				header: (
-					<div>
-						Stock Received <br />
-						Date
-					</div>
-				),
-				enableColumnFilter: false,
-				cell: (info) => {
-					return <DateTime date={info.getValue()} />;
 				},
 			},
 			{


### PR DESCRIPTION
Introduce status date and batch status date fields to enhance tracking of dyeing processes. Update UI components to display these dates alongside relevant status indicators.