### PR TITLE
Update report fields to use ' -- ' as separator for Excel export

### DIFF
--- a/src/pages/Report/DailtChallanDR/index.jsx
+++ b/src/pages/Report/DailtChallanDR/index.jsx
@@ -242,7 +242,7 @@ export default function Index() {
 					const { lc_numbers } = row;
 					if (lc_numbers === null) return '--';
 
-					return lc_numbers?.map((lc) => lc?.lc_number).join(', ');
+					return lc_numbers?.map((lc) => lc?.lc_number).join(' -- ');
 				},
 				id: 'lc_numbers',
 				header: 'LC No.',
@@ -267,7 +267,7 @@ export default function Index() {
 					const { pi_numbers } = row;
 					if (pi_numbers === null) return '--';
 
-					return pi_numbers?.map((pi) => pi?.pi_number).join(', ');
+					return pi_numbers?.map((pi) => pi?.pi_number).join(' -- ');
 				},
 				id: 'pi_numbers',
 				header: 'Pi No.',

--- a/src/pages/Report/OrderTracking/index.jsx
+++ b/src/pages/Report/OrderTracking/index.jsx
@@ -326,7 +326,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.dyeing_batch
 						?.map((item) => item.dyeing_batch_number)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'dyeing_batch',
 				header: 'Dyeing Batch',
@@ -365,7 +365,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.finishing_batch
 						?.map((item) => item.finishing_batch_number)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'finishing_batch',
 				header: 'Finishing Batch',

--- a/src/pages/Report/PIToBeSubmit/MarketingWise.jsx
+++ b/src/pages/Report/PIToBeSubmit/MarketingWise.jsx
@@ -37,7 +37,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.order_object
 						.map((order) => order.label)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'order_object',
 				header: 'O/N',

--- a/src/pages/Report/PIToBeSubmit/PartyWise.jsx
+++ b/src/pages/Report/PIToBeSubmit/PartyWise.jsx
@@ -37,7 +37,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.order_object
 						.map((order) => order.label)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'order_object',
 				header: 'O/N',

--- a/src/pages/Report/PackingList/index.jsx
+++ b/src/pages/Report/PackingList/index.jsx
@@ -97,19 +97,19 @@ export default function Index() {
 				accessorKey: 'item_type',
 				header: 'Item',
 				enableColumnFilter: false,
-				cell: (info) => info.getValue()?.join(', '),
+				cell: (info) => info.getValue()?.join(' -- '),
 			},
 			{
 				accessorKey: 'zipper_number_name',
 				header: 'Zipper No.',
 				enableColumnFilter: false,
-				cell: (info) => info.getValue()?.join(', '),
+				cell: (info) => info.getValue()?.join(' -- '),
 			},
 			{
 				accessorKey: 'end_type_name',
 				header: 'End Type',
 				enableColumnFilter: false,
-				cell: (info) => info.getValue()?.join(', '),
+				cell: (info) => info.getValue()?.join(' -- '),
 			},
 			{
 				accessorFn: (row) => (row.is_warehouse_received ? 'Y' : 'N'),
@@ -187,7 +187,7 @@ export default function Index() {
 						row.item_description?.map((item) => item)
 					);
 
-					return [...uniqueItemDescription].join(', ');
+					return [...uniqueItemDescription].join(' -- ');
 				},
 				id: 'item_description',
 				header: <>Item Description</>,
@@ -200,14 +200,14 @@ export default function Index() {
 				header: 'Style',
 				enableColumnFilter: false,
 				width: 'w-32',
-				cell: (info) => info.getValue().join(', '),
+				cell: (info) => info.getValue().join(' -- '),
 			},
 			{
 				accessorKey: 'color',
 				header: 'Color',
 				enableColumnFilter: false,
 				width: 'w-32',
-				cell: (info) => info.getValue().join(', '),
+				cell: (info) => info.getValue().join(' -- '),
 			},
 			{
 				accessorKey: 'unit',
@@ -224,7 +224,7 @@ export default function Index() {
 					if (row?.pi_numbers == null) return '--';
 
 					const pis = row.pi_numbers?.map((pi) => pi.pi_numbers);
-					return pis.join(', ');
+					return pis.join(' -- ');
 				},
 				id: 'pi_numbers',
 				header: <>Pi No.</>,

--- a/src/pages/Report/Sample/index.jsx
+++ b/src/pages/Report/Sample/index.jsx
@@ -214,7 +214,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.challan_info
 						?.map((item) => item.challan_number)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'challan_info',
 				header: 'Challan Info',

--- a/src/pages/Report/ThreadBatch/index.jsx
+++ b/src/pages/Report/ThreadBatch/index.jsx
@@ -63,7 +63,7 @@ export default function Index() {
 					if (order_numbers) {
 						concat = order_numbers
 							.map((order_number) => order_number.order_number)
-							.join(', ');
+							.join(' -- ');
 					}
 
 					return concat;
@@ -117,7 +117,7 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
-				accessorFn: (row) => row.color.join(', '),
+				accessorFn: (row) => row.color.join(' -- '),
 				id: 'color',
 				header: 'Color',
 				enableColumnFilter: false,
@@ -125,7 +125,7 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
-				accessorFn: (row) => row.recipe_name.join(', '),
+				accessorFn: (row) => row.recipe_name.join(' -- '),
 				id: 'recipe_name',
 				header: 'Shade',
 				width: 'w-24',

--- a/src/pages/Report/ThreadProductionStatusOrderWise/index.jsx
+++ b/src/pages/Report/ThreadProductionStatusOrderWise/index.jsx
@@ -161,7 +161,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.thread_batch
 						?.map((item) => item.finishing_batch_number)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'thread_batch',
 				header: 'Thread Batch',

--- a/src/pages/Report/ZipperBatch/index.jsx
+++ b/src/pages/Report/ZipperBatch/index.jsx
@@ -71,7 +71,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.order_numbers
 						?.map((order_number) => order_number)
-						?.join(', ');
+						?.join(' -- ');
 				},
 				id: 'order_numbers',
 				header: 'O/N',
@@ -95,7 +95,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.item_descriptions
 						?.map((item) => item.item_description)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'item_descriptions',
 				header: 'Item Description',
@@ -148,7 +148,7 @@ export default function Index() {
 			},
 			{
 				accessorFn: (row) =>
-					row.style?.map((style) => style)?.join(', '),
+					row.style?.map((style) => style)?.join(' -- '),
 				id: 'style',
 				header: 'Style',
 				width: 'w-24',
@@ -157,7 +157,7 @@ export default function Index() {
 			},
 			{
 				accessorFn: (row) =>
-					row.color?.map((color) => color)?.join(', '),
+					row.color?.map((color) => color)?.join(' -- '),
 				id: 'color',
 				header: 'Color',
 				width: 'w-24',

--- a/src/pages/Report/ZipperProductionStatus/index.jsx
+++ b/src/pages/Report/ZipperProductionStatus/index.jsx
@@ -133,7 +133,7 @@ export default function Index() {
 				},
 			},
 			{
-				accessorFn: (row) => row.colors.join(', '),
+				accessorFn: (row) => row.colors.join(' -- '),
 				id: 'colors',
 				header: 'Colors',
 				enableColumnFilter: false,
@@ -149,7 +149,7 @@ export default function Index() {
 				cell: (info) => info.getValue(),
 			},
 			{
-				accessorFn: (row) => row.styles.join(', '),
+				accessorFn: (row) => row.styles.join(' -- '),
 				id: 'styles',
 				header: 'Styles',
 				enableColumnFilter: false,
@@ -214,7 +214,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.dyeing_batch
 						?.map((item) => item.dyeing_batch_number)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'dyeing_batch',
 				header: 'Dyeing Batch',
@@ -267,7 +267,7 @@ export default function Index() {
 				accessorFn: (row) => {
 					return row.finishing_batch
 						?.map((item) => item.finishing_batch_number)
-						.join(', ');
+						.join(' -- ');
 				},
 				id: 'finishing_batch',
 				header: 'Finishing Batch',


### PR DESCRIPTION
Change the separator for various report fields in Excel exports from ', ' to ' -- ' for improved readability.