### PR TITLE
Require double for yarn issued in production schema

### DIFF
--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -2955,10 +2955,7 @@ export const DYEING_THREAD_BATCH_NULL = {
 // * Dyeing Planning Batch production schema*//
 
 export const DYEING_BATCH_PRODUCTION_SCHEMA = {
-	yarn_issued: NUMBER_DOUBLE_REQUIRED.moreThan(
-		0,
-		'Yarn Issued should be more than 0'
-	),
+	yarn_issued: NUMBER_DOUBLE.nullable(),
 	dyeing_batch_entry: yup.array().of(
 		yup.object().shape({
 			production_quantity: NUMBER.nullable() // Allows the field to be null
@@ -2987,7 +2984,7 @@ export const DYEING_BATCH_PRODUCTION_NULL = {
 	],
 };
 export const DYEING_BATCH_YARN_ISSUE_SCHEMA = {
-	yarn_issued: NUMBER_REQUIRED.moreThan(
+	yarn_issued: NUMBER_DOUBLE_REQUIRED.moreThan(
 		0,
 		'Yarn Issued should be more than 0'
 	),

--- a/src/util/Schema/index.jsx
+++ b/src/util/Schema/index.jsx
@@ -2955,7 +2955,7 @@ export const DYEING_THREAD_BATCH_NULL = {
 // * Dyeing Planning Batch production schema*//
 
 export const DYEING_BATCH_PRODUCTION_SCHEMA = {
-	yarn_issued: NUMBER_REQUIRED.moreThan(
+	yarn_issued: NUMBER_DOUBLE_REQUIRED.moreThan(
 		0,
 		'Yarn Issued should be more than 0'
 	),


### PR DESCRIPTION
Update the DYEING_BATCH_PRODUCTION_SCHEMA to enforce that the yarn issued is a double, ensuring more precise data handling.