### PR TITLE
Enable button regardless of update state and clean up form attributes

### DIFF
--- a/src/pages/DyeingAndIron/ZipperBatch/Production/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/Production/index.jsx
@@ -273,7 +273,6 @@ export default function Index() {
 							<input
 								type='button'
 								className='btn btn-primary btn-xs'
-								disabled={isUpdate}
 								value={'Copy'}
 								onClick={() =>
 									setValue(


### PR DESCRIPTION
Remove the disabled state from the button to allow interaction regardless of the update state, and streamline form attributes for better clarity.