### PR TITLE
Add updated_at and updated_by fields to LabDip and ZipperSwatch submissions

### DIFF
--- a/src/pages/DyeingAndIron/ZipperBatch/Production/Header.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/Production/Header.jsx
@@ -174,11 +174,7 @@ export default function Header({
 						}}
 					/>
 				</FormField>
-				<Textarea
-					label='remarks'
-					{...{ register, errors }}
-					disabled={true}
-				/>
+				<Textarea label='remarks' {...{ register, errors }} />
 
 				{/* </div> */}
 			</SectionEntryBody>

--- a/src/pages/DyeingAndIron/ZipperBatch/Production/index.jsx
+++ b/src/pages/DyeingAndIron/ZipperBatch/Production/index.jsx
@@ -115,6 +115,7 @@ export default function Index() {
 						: GetDateTime(),
 				updated_at: GetDateTime(),
 				updated_by: user?.uuid,
+				remarks: data.remarks,
 			},
 			isOnCloseNeeded: false,
 		});

--- a/src/pages/LabDip/ThreadSwatch/index.jsx
+++ b/src/pages/LabDip/ThreadSwatch/index.jsx
@@ -62,6 +62,8 @@ export default function Index() {
 					? null
 					: GetDateTime(),
 				swatch_approval_received_by: user?.uuid,
+				updated_at: GetDateTime(),
+				updated_by: user?.uuid,
 			},
 			isOnCloseNeeded: false,
 		});
@@ -326,6 +328,8 @@ export default function Index() {
 			updatedData: {
 				recipe_uuid: e.value,
 				swatch_approval_date: GetDateTime(),
+				updated_at: GetDateTime(),
+				updated_by: user?.uuid,
 			},
 			isOnCloseNeeded: false,
 		});

--- a/src/pages/LabDip/ZipperSwatch/index.jsx
+++ b/src/pages/LabDip/ZipperSwatch/index.jsx
@@ -58,6 +58,8 @@ export default function Index() {
 				updatedData: {
 					recipe_uuid: e.value,
 					swatch_approval_date: GetDateTime(),
+					updated_at: GetDateTime(),
+					updated_by: user?.uuid,
 				},
 				isOnCloseNeeded: false,
 			});
@@ -73,6 +75,8 @@ export default function Index() {
 					uuids: bulkSwatch[idx].uuids,
 					recipe_uuid: e.value,
 					swatch_approval_date: GetDateTime(),
+					updated_at: GetDateTime(),
+					updated_by: user?.uuid,
 				},
 				isOnCloseNeeded: false,
 			});
@@ -95,6 +99,8 @@ export default function Index() {
 						? null
 						: GetDateTime(),
 					swatch_approval_received_by: user?.uuid,
+					updated_at: GetDateTime(),
+					updated_by: user?.uuid,
 				},
 				isOnCloseNeeded: false,
 			});
@@ -116,6 +122,8 @@ export default function Index() {
 						? null
 						: GetDateTime(),
 					swatch_approval_received_by: user?.uuid,
+					updated_at: GetDateTime(),
+					updated_by: user?.uuid,
 				},
 				isOnCloseNeeded: false,
 			});


### PR DESCRIPTION
Enhance data submissions in the LabDip and ZipperSwatch components by including `updated_at` and `updated_by` fields for better tracking of changes. Additionally, streamline the remarks field handling.