### PR TITLE
Rename accessor key for swatch approval date for clarity

### DIFF
--- a/src/pages/Report/OrderStatusZipper/Zipper.jsx
+++ b/src/pages/Report/OrderStatusZipper/Zipper.jsx
@@ -171,7 +171,7 @@ export default function Index() {
 				cell: (info) => <Status status={info.getValue()} />,
 			},
 			{
-				accessorKey: 'swatch_approval_date',
+				accessorKey: 'swatch_approval_received_date',
 				header: (
 					<>
 						Swatch <br />


### PR DESCRIPTION
Clarify the accessor key for swatch approval date by renaming it to swatch approval received date.